### PR TITLE
Fix 'Avoid use of cache directory with pip. Use `pip install --no-cache-dir <package>`' issue in backend\Dockerfile

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -4,4 +4,4 @@ COPY . /app
 
 WORKDIR /app/app
 
-RUN pip install -r ../requirements.txt
+RUN pip install --no-cache-dir -r ../requirements.txt


### PR DESCRIPTION
[CodeFactor](https://www.codefactor.io/repository/github/streamchaser/streamchaser) found an issue: Avoid use of cache directory with pip. Use `pip install --no-cache-dir <package>`

It's currently on:
[backend\Dockerfile:7](https://www.codefactor.io/repository/github/streamchaser/streamchaser/source/master/backend/Dockerfile#L7)