### PR TITLE
Choose country in navbar not disabled & remove countryCode from title

### DIFF
--- a/frontend/src/components/navbar.svelte
+++ b/frontend/src/components/navbar.svelte
@@ -28,7 +28,7 @@
     <div class="sm:pl-4">
         <select bind:value={selectedCountry} on:change={currentCountry.set(selectedCountry)}
                 class="select select-ghost select-bordered max-sm">
-            <option disabled={false}>Choose country</option>
+            <option disabled={true}>Choose country</option>
             {#each countries as country}
                 <option value={country.value}>{country.name}</option>
             {/each}

--- a/frontend/src/routes/index.svelte
+++ b/frontend/src/routes/index.svelte
@@ -126,7 +126,7 @@
 </script>
 
 <svelte:head>
-    <title>Streamchaser {$currentCountry}</title>
+    <title>Streamchaser</title>
 </svelte:head>
 
 <div class="flex flex-col h-screen justify-between">


### PR DESCRIPTION
### Before reporting

- [X] I have tested with the lastest _master_

### Describe the bug

You can choose `Choose country` as country in the navbar.

### To Reproduce

Try to click choose country in the navbar

### Expected behavior

It should be disabled

### Additional context

_No response_