### PR TITLE
Console log mulitiselect spam

### DIFF
--- a/frontend/src/routes/index.svelte
+++ b/frontend/src/routes/index.svelte
@@ -25,8 +25,8 @@
     let media = [];
     let selectedGenres = [];
     let providerAmounts: number[] = [];
-    let formattedGenres: {} = {};
-    let activeProviders = [];
+    let formattedGenres: {} = {'':''};
+    let activeProviders = [''];
     let currentMediaAmount: number = 21;
 
     // run search if we haven't received input in the last 200ms


### PR DESCRIPTION
### Before reporting

- [X] I have tested with the lastest _master_

### Describe the bug

Multiselects atm give a error on page load:

![image](https://user-images.githubusercontent.com/50198099/139920333-a0f32fac-1907-4b30-b276-702e82ff551f.png)


### To Reproduce

Go to the site and look at console log

### Expected behavior

No errors from multiselects on page load

### Additional context

_No response_