### PR TITLE
Firefox dynamic import loads error page

### DIFF
--- a/frontend/src/routes/__error.svelte
+++ b/frontend/src/routes/__error.svelte
@@ -1,16 +1,28 @@
 <script lang="ts">
-    import Navbar from '../components/navbar.svelte';
-    import Footer from '../components/footer.svelte';
-    import Error from '../components/error.svelte';
+    import Navbar from "../components/navbar.svelte";
+    import Footer from "../components/footer.svelte";
+    import Error from "../components/error.svelte";
+    import { onMount } from "svelte";
 
+    // This is a temp fix for the firefox dyanmic import bug
+    // TODO: Find a proper way to fix the dynamic import issue a remove this
+    let loadError = false;
+
+    onMount(async () => {
+        setTimeout(() => (loadError = true), 100);
+    });
 </script>
 
 <svelte:head>
-    <title>404 Page not found</title>
+    {#if loadError}
+        <title>404 Page not found</title>
+    {/if}
 </svelte:head>
 
-<div class="flex flex-col h-screen justify-between">
-    <Navbar />
-    <Error error={'404 Page not found'} />
-    <Footer/>
-</div>
+{#if loadError}
+    <div class="flex flex-col h-screen justify-between">
+        <Navbar />
+        <Error error={"404 Page not found"} />
+        <Footer />
+    </div>
+{/if}


### PR DESCRIPTION
### Before reporting

- [X] I have tested with the lastest _master_

### Describe the bug

In firefox the error page will shortly show itself whjen loading a page since it gets the dynamic import error

### To Reproduce

Go to index page
Route anywhere else in the program
Repeat

### Expected behavior

Error page should not be shown if the request is succesful

### Additional context

This is a temp fix that just delays the error page