### PR TITLE
+ number providers doesnt work

### DIFF
--- a/frontend/src/routes/index.svelte
+++ b/frontend/src/routes/index.svelte
@@ -191,7 +191,7 @@
                                     {/each}
                                     <div class="avatar placeholder">
                                         <div class="w-12 h-12 rounded-full bg-neutral-focus text-neutral-content">
-                                            <span>+{providerAmounts[mediaIndex] -  + 1}</span>
+                                            <span>+{providerAmounts[mediaIndex] - SHOWN_PROVIDERS  + 1}</span>
                                         </div>
                                     </div>
                                 </div>


### PR DESCRIPTION
### Before reporting

- [X] I have tested with the lastest _master_

### Describe the bug

Right now if you find a media with 6 or more providers the `+ number` providers will always show the total amount of providers - 1

### To Reproduce

Go to index page
Find a movie/tv serie with 6 or more providers

### Expected behavior

It should show the correct amount of providers

### Additional context

_No response_