### PR TITLE
Add print statements for meilisearch indexing

### DIFF
--- a/backend/app/cli.py
+++ b/backend/app/cli.py
@@ -71,8 +71,10 @@ def fetch_media(total_pages: int) -> bool:
 
 @app.command()
 def index_meilisearch():
+    typer.echo("Meilisearch is indexing...")
     init_meilisearch_indexing()
     update_index()
+    typer.echo("Meilisearch done indexing!")
 
 
 @app.command()
@@ -131,6 +133,7 @@ def full_setup(total_pages: int, remove_non_ascii: bool = True):
         index_meilisearch()
         update_index()
         remove_blacklisted_from_search()
+        typer.echo('Full setup complete!')
 
 
 @app.command()

--- a/backend/app/db/database_service.py
+++ b/backend/app/db/database_service.py
@@ -82,6 +82,11 @@ def init_meilisearch_indexing():
     try:
         media_list = crud.get_all_media(db=db)
 
+        print(
+            f'Meilisearch indexing {len(supported_country_codes)} x '
+            f'{len(media_list)} elements...'
+        )
+
         for country_code in supported_country_codes:
             media_list_as_dict = [
                 schemas.Media(
@@ -109,11 +114,6 @@ def init_meilisearch_indexing():
             client.index(f'media_{country_code}').add_documents(media_list_as_dict)
 
             extract_unique_providers_to_txt(media_list, country_code)
-
-        print(
-            f'Meilisearch indexing {len(supported_country_codes)} x '
-            f'{len(media_list)} elements'
-        )
 
     except Exception as e:
         print(f'Error in database_service.py::init_meilisearch_indexing {e}')

--- a/backend/app/db/database_service.py
+++ b/backend/app/db/database_service.py
@@ -82,11 +82,6 @@ def init_meilisearch_indexing():
     try:
         media_list = crud.get_all_media(db=db)
 
-        print(
-            f'Meilisearch indexing {len(supported_country_codes)} x '
-            f'{len(media_list)} elements...'
-        )
-
         for country_code in supported_country_codes:
             media_list_as_dict = [
                 schemas.Media(


### PR DESCRIPTION
### Is your feature request related to a problem? Please describe.

It's annoying not being able to see if meilisearch is stalling or actually indexing, adding some print statements for
what it is indexing would be nice.

### Describe the solution you'd like

Add print statements to the meilisearch indexing step

### Describe alternatives you've considered

_No response_

### Additional context

_No response_