### PR TITLE
Genre & providers shown in no results on index page

### DIFF
--- a/frontend/src/components/no_results.svelte
+++ b/frontend/src/components/no_results.svelte
@@ -1,0 +1,24 @@
+<script lang="ts">
+    export let currentProviders: [];
+    export let currentGenres: [];
+    export let input: string;
+</script>
+
+<div class="flex flex-col">
+    <div class="m-auto text-center max-w-xl">
+        <p>No results for:</p>
+        <p><b><i>{input ? input : "<No input>"}</i></b></p>
+        {#if currentGenres.length > 0}
+            <p class="pt-2">Genres:</p>
+            {#each currentGenres as genre}
+                <div class="badge mx-1">{genre}</div>
+            {/each}
+        {/if}
+        {#if currentProviders.length > 0}
+            <p class="pt-2">Providers:</p>
+            {#each currentProviders as provider}
+                <div class="badge mx-1">{provider}</div>
+            {/each}
+        {/if}
+    </div>
+</div>

--- a/frontend/src/components/no_results.svelte
+++ b/frontend/src/components/no_results.svelte
@@ -5,7 +5,7 @@
 </script>
 
 <div class="flex flex-col">
-    <div class="m-auto text-center max-w-xl">
+    <div class="m-auto text-center max-w-md">
         <p>No results for:</p>
         <p><b><i>{input ? input : "<No input>"}</i></b></p>
         {#if currentGenres.length > 0}
@@ -13,12 +13,14 @@
             {#each currentGenres as genre}
                 <div class="badge mx-1">{genre}</div>
             {/each}
+                <p class="text-xs pt-1"><i>Consider using less genres</i></p>
         {/if}
         {#if currentProviders.length > 0}
             <p class="pt-2">Providers:</p>
             {#each currentProviders as provider}
                 <div class="badge mx-1">{provider}</div>
             {/each}
+                <p class="text-xs pt-1"><i>Consider adding more providers or removing all</i></p>
         {/if}
     </div>
 </div>

--- a/frontend/src/routes/index.svelte
+++ b/frontend/src/routes/index.svelte
@@ -3,6 +3,7 @@
 	import { variables } from '../variables.js'
     import Navbar from '../components/navbar.svelte';
     import Footer from '../components/footer.svelte';
+    import NoResults from '../components/no_results.svelte';
     import CookieDisclaimer from '../components/cookie_disclaimer.svelte'
     import MultiSelect from 'svelte-multiselect'
     import {currentCountry} from '../stores/country.js';
@@ -234,32 +235,11 @@
                     {/if}
                 </div>
             {:else}
-                <div class="flex flex-col">
-                    <div class="m-auto text-center max-w-xl">
-                        <p>No results for:</p>
-                        <p class="pb-1"><b><i>{input}</i></b></p>
-                        {#if $currentGenres.length > 0 && $currentProviders.length > 0}
-                            <p>With genres:</p>
-                            {#each $currentGenres as genre}
-                                <div class="badge mx-1">{genre}</div>
-                            {/each}
-                            <p class="pt-1">And providers:</p>
-                            {#each $currentProviders as provider}
-                                <div class="badge mx-1">{provider}</div>
-                            {/each}
-                        {:else if $currentGenres.length > 0}
-                            <p>With genres:</p>
-                            {#each $currentGenres as genre}
-                                <div class="badge mx-1">{genre}</div>
-                            {/each}
-                        {:else if $currentProviders.length > 0}
-                            <p>With providers:</p>
-                            {#each $currentProviders as provider}
-                                <div class="badge mx-1">{provider}</div>
-                            {/each}
-                        {/if}
-                    </div>
-                </div>
+                <NoResults
+                    currentProviders={$currentProviders}
+                    currentGenres={$currentGenres}
+                    input={input}
+                />
             {/if}
         {/if}
     </div>

--- a/frontend/src/routes/index.svelte
+++ b/frontend/src/routes/index.svelte
@@ -234,8 +234,31 @@
                     {/if}
                 </div>
             {:else}
-                <div class="flex justify-around">
-                    <p>No results for: {input}</p>
+                <div class="flex flex-col">
+                    <div class="m-auto text-center max-w-xl">
+                        <p>No results for:</p>
+                        <p class="pb-1"><b><i>{input}</i></b></p>
+                        {#if $currentGenres.length > 0 && $currentProviders.length > 0}
+                            <p>With genres:</p>
+                            {#each $currentGenres as genre}
+                                <div class="badge mx-1">{genre}</div>
+                            {/each}
+                            <p class="pt-1">And providers:</p>
+                            {#each $currentProviders as provider}
+                                <div class="badge mx-1">{provider}</div>
+                            {/each}
+                        {:else if $currentGenres.length > 0}
+                            <p>With genres:</p>
+                            {#each $currentGenres as genre}
+                                <div class="badge mx-1">{genre}</div>
+                            {/each}
+                        {:else if $currentProviders.length > 0}
+                            <p>With providers:</p>
+                            {#each $currentProviders as provider}
+                                <div class="badge mx-1">{provider}</div>
+                            {/each}
+                        {/if}
+                    </div>
                 </div>
             {/if}
         {/if}


### PR DESCRIPTION
### Is your feature request related to a problem? Please describe.

I would like to see what genres/providers i have selected when getting no results on index page

### Describe the solution you'd like

Having the list of genres & providers you have chosen shown when no results pops up

### Describe alternatives you've considered

_No response_

### Additional context

_No response_