### PR TITLE
Handle long descriptions in detailsview

### DIFF
--- a/frontend/src/components/read_more.svelte
+++ b/frontend/src/components/read_more.svelte
@@ -1,0 +1,16 @@
+<script lang="ts">
+    export let currentDescriptionLength;
+    export let mediaDescription;
+    export let initialDescriptionLength;
+</script>
+
+{#if currentDescriptionLength <= initialDescriptionLength && mediaDescription.length > initialDescriptionLength}
+    <p>{mediaDescription.slice(0, currentDescriptionLength)}
+        <a href="" class="cursor-pointer text-blue-400"
+        on:click={() => currentDescriptionLength = mediaDescription.length}>
+        <i>...read more</i>
+        </a>
+    </p>
+{:else}
+    <p>{mediaDescription}</p>
+{/if}

--- a/frontend/src/routes/movie/[id].svelte
+++ b/frontend/src/routes/movie/[id].svelte
@@ -8,6 +8,7 @@
     import Error from '../../components/error.svelte';
     import Person from '../../components/person.svelte';
     import CookieDisclaimer from '../../components/cookie_disclaimer.svelte'
+    import ReadMore from '../../components/read_more.svelte'
 
 
 	const MOVIE_DETAIL_URL: string = `${variables.apiPath}/movie/${$currentCountry}/${$page.params.id}`;
@@ -15,8 +16,10 @@
 	const LOW_RES_IMG_URL: string = 'https://image.tmdb.org/t/p/w500/';
 	const SHOW_BUTTON_AMOUNT: number = 18;
 	const CAST_ITEM_START_AMOUNT: number = 9;
+    const INITIAL_DESCRIPTION_LENGTH = 500;
 
 	let movieTitle: string = 'Loading...';
+    let currentDescriptionLength = INITIAL_DESCRIPTION_LENGTH;
 
 	const fetchMovieDetails = async () => {
 		const response = await fetch(MOVIE_DETAIL_URL);
@@ -72,7 +75,9 @@
 					</figure>
 					<div class="max-w-md card-body">
 						<h2 class="card-title">{movie.title}</h2>
-						<p>{movie.overview}</p>
+                        <ReadMore currentDescriptionLength={currentDescriptionLength}
+                                  mediaDescription={movie.overview}
+                                  initialDescriptionLength={INITIAL_DESCRIPTION_LENGTH}/>
 						<div class="flex-wrap mt-2">
 							{#each movie.genres as genre}
 								<div class="badge mx-2">{genre}</div>

--- a/frontend/src/routes/person/[id].svelte
+++ b/frontend/src/routes/person/[id].svelte
@@ -11,9 +11,11 @@
     const PERSON_DETAIL_URL: string = `${variables.apiPath}/person/${$page.params.id}`;
     const IMG_URL: string = 'https://image.tmdb.org/t/p/original/';
     const LOW_RES_IMG_URL: string = 'https://image.tmdb.org/t/p/w500/';
+    const INITIAL_BIOGRAPHY_LENGTH: number = 500;
     const SHOW_BUTTON_AMOUNT: number = 12;
     const CAST_ITEM_START_AMOUNT: number = 6;
 
+    let currentBiographyLength: number = INITIAL_BIOGRAPHY_LENGTH;
     let currentMovieAmount: number = 6;
     let currentTVAmount: number = 6;
     let personName: string = 'Loading...';
@@ -67,7 +69,16 @@
                     </figure>
                     <div class="max-w-md card-body">
                         <h2 class="card-title">{person.name}</h2>
-                        <p>{person.biography}</p>
+                        {#if currentBiographyLength <= INITIAL_BIOGRAPHY_LENGTH && person.biography.length > INITIAL_BIOGRAPHY_LENGTH}
+                            <p>{person.biography.slice(0, currentBiographyLength)}
+                                <a href="" class="cursor-pointer"
+                                    on:click={() => currentBiographyLength = person.biography.length}>
+                                    ...read more
+                                </a>
+                            </p>
+                        {:else}
+                            <p>{person.biography}</p>
+                        {/if}
                     </div>
                 </div>
             </div>

--- a/frontend/src/routes/person/[id].svelte
+++ b/frontend/src/routes/person/[id].svelte
@@ -6,6 +6,7 @@
     import Footer from '../../components/footer.svelte';
     import Error from '../../components/error.svelte';
     import CookieDisclaimer from '../../components/cookie_disclaimer.svelte'
+    import ReadMore from '../../components/read_more.svelte'
 
 
     const PERSON_DETAIL_URL: string = `${variables.apiPath}/person/${$page.params.id}`;
@@ -69,16 +70,10 @@
                     </figure>
                     <div class="max-w-md card-body">
                         <h2 class="card-title">{person.name}</h2>
-                        {#if currentBiographyLength <= INITIAL_BIOGRAPHY_LENGTH && person.biography.length > INITIAL_BIOGRAPHY_LENGTH}
-                            <p>{person.biography.slice(0, currentBiographyLength)}
-                                <a href="" class="cursor-pointer"
-                                    on:click={() => currentBiographyLength = person.biography.length}>
-                                    ...read more
-                                </a>
-                            </p>
-                        {:else}
-                            <p>{person.biography}</p>
-                        {/if}
+                        <ReadMore currentDescriptionLength={currentBiographyLength}
+                                  mediaDescription={person.biography}
+                                  initialDescriptionLength={INITIAL_BIOGRAPHY_LENGTH}
+                        />
                     </div>
                 </div>
             </div>

--- a/frontend/src/routes/tv/[id].svelte
+++ b/frontend/src/routes/tv/[id].svelte
@@ -9,6 +9,7 @@
     import Error from '../../components/error.svelte';
     import Person from '../../components/person.svelte';
     import CookieDisclaimer from '../../components/cookie_disclaimer.svelte'
+    import ReadMore from '../../components/read_more.svelte'
 
 
     const TV_DETAIL_URL: string = `${variables.apiPath}/tv/${$currentCountry}/${$page.params.id}`;
@@ -16,8 +17,10 @@
     const LOW_RES_IMG_URL: string = 'https://image.tmdb.org/t/p/w500/';
 	const SHOW_BUTTON_AMOUNT: number = 18;
 	const CAST_ITEM_START_AMOUNT: number = 9;
+    const INITIAL_DESCRIPTION_LENGTH = 500;
 
     let tvTitle = 'Loading...';
+    let currentDescriptionLength = INITIAL_DESCRIPTION_LENGTH;
 
     const fetchTVDetails = async () => {
 		const response = await fetch(TV_DETAIL_URL);
@@ -73,7 +76,10 @@
                     </figure>
                     <div class="max-w-md card-body">
                         <h2 class="card-title">{tv.name}</h2>
-                        <p>{tv.overview}</p>
+                        <ReadMore currentDescriptionLength={currentDescriptionLength}
+                                  mediaDescription={tv.overview}
+                                  initialDescriptionLength={INITIAL_DESCRIPTION_LENGTH}
+                        />
                         <div class="flex-wrap mt-2">
                             {#each tv.genres as genre}
                                 <div class="badge mx-2">{genre}</div>


### PR DESCRIPTION
### Is your feature request related to a problem? Please describe.

Right now the detailsview descriptions can get very long and out of hand. 

![image](https://user-images.githubusercontent.com/50198099/140313265-f9efeef8-10da-41c8-83aa-0178973eb843.png)

https://streamchaser.tv/person/18918

### Describe the solution you'd like

If like the description length was fixed, and you could simply press `show more` to get the full description

### Describe alternatives you've considered

_No response_

### Additional context

_No response_