### PR TITLE
Better handling of card in detailsview

### DIFF
--- a/frontend/src/components/details/read_more.svelte
+++ b/frontend/src/components/details/read_more.svelte
@@ -6,7 +6,7 @@
 
 {#if currentDescriptionLength <= initialDescriptionLength && mediaDescription.length > initialDescriptionLength}
     <p>{mediaDescription.slice(0, currentDescriptionLength)}
-        <a href="" class="cursor-pointer text-blue-400"
+        <a href="" class="cursor-pointer text-blue-500"
         on:click={() => currentDescriptionLength = mediaDescription.length}>
         <i>...read more</i>
         </a>

--- a/frontend/src/components/details/top_card.svelte
+++ b/frontend/src/components/details/top_card.svelte
@@ -18,7 +18,7 @@
 <div
     class="flex items-center w-full px-4 py-10 bg-cover card bg-base-200"
     style="background-image: url(&quot;{IMG_URL}{backdropPath}&quot;);e">
-    <div class="card glass lg:card-side text-neutral-content">
+    <div class="card lg:card-side bg-gray-700 bg-opacity-90 bordered text-neutral-content">
         <figure class="p-6">
             <img
                 src="{IMG_URL}{posterPath}"
@@ -26,7 +26,7 @@
                 alt={title}
             />
         </figure>
-        <div class="max-w-md card-body">
+        <div class="card-body max-w-md">
             <h2 class="card-title">{title}</h2>
             <ReadMore
                 currentDescriptionLength={currentOverviewLength}
@@ -42,11 +42,12 @@
             {/if}
         </div>
     </div>
+
     {#if providers}
         <div class="flex-nowrap pt-5">
             {#each providers as provider}
-                <div class="avatar p-2">
-                    <div class="mb-8 w-24 h-24 mask mask-squircle">
+                <div class="avatar p-1">
+                    <div class="mb-8 w-20 h-20 mask mask-squircle">
                         <img
                             src="{IMG_URL}{provider.logo_path}"
                             alt={provider.provider_name}

--- a/frontend/src/components/error.svelte
+++ b/frontend/src/components/error.svelte
@@ -1,16 +1,12 @@
 <script lang="ts">
     export let error;
-
-    const goBack = () => {
-        window.history.back();
-    }
 </script>
 <div>
     <h1 class="flex justify-center text-3xl">┻━┻ ︵ヽ(`Д´)ﾉ︵ ┻━┻</h1><br>
     <h2 class="flex justify-center">The requested site could not be reached</h2><br>
     <div class="flex justify-center">
         <button
-            on:click={() => goBack()}
+            on:click={() => window.history.back()}
             id="goback"
             type="button"
             class="btn">

--- a/frontend/src/components/footer.svelte
+++ b/frontend/src/components/footer.svelte
@@ -12,11 +12,12 @@
             </a>
         </div>
         <div>
-            <p>Copyright © 2021 - All rights reserved by <a class="link link-hover"
-                                                                           href="https://github.com/orgs/streamchaser">Streamchaser</a>
+            <p class="pb-5">Copyright © 2021 - All rights reserved by
+                <a class="link link-hover"
+                    href="https://github.com/orgs/streamchaser">Streamchaser</a>
             </p>
-            <p><a href="https://www.themoviedb.org/">
-                <img class="w-20 h-20 inline" src="../../tmdb.svg/" alt="The Movie Database logo">
+            <p class="pb-2"><a href="https://www.themoviedb.org/">
+                <img class="w-20 inline" src="../../tmdb.svg/" alt="The Movie Database logo">
             </a> &nbsp This product uses the TMDB API but is not endorsed or
                 certified by TMDB
         </div>


### PR DESCRIPTION
### Is your feature request related to a problem? Please describe.

Right now the card on details views uses glass blur. This is disabled by default in fx. `firefox`, and makes it very hard to read the content of the card.
![image](https://user-images.githubusercontent.com/50198099/140312151-2a736731-23f9-46f5-904a-7c88577dc3a1.png)

https://streamchaser.tv/tv/93405

Even sometimes in browsers that support glass blur it can be hard to decode what is inside the card.
![image](https://user-images.githubusercontent.com/50198099/140312336-f4258937-ae33-4f36-9213-d48160397c6e.png)

https://streamchaser.tv/person/56730

### Describe the solution you'd like

I would like a detailsview card where we can always see the content of the card. Furthermore a solution that supports all browsers by default.

### Describe alternatives you've considered

_No response_

### Additional context

_No response_