### PR TITLE
Make recommendation size better for mobile & non-mobile

### DIFF
--- a/frontend/src/components/details/recommendations.svelte
+++ b/frontend/src/components/details/recommendations.svelte
@@ -7,7 +7,7 @@
     export let mediaType: string
 </script>
 
-{#if recommendations.length}
+{#if recommendations.length >= 5}
     <h1 class="text-center text-3xl pt-5">Recommendations</h1>
     <div class="pt-5">
         <div class="p-4 space-x-4 carousel carousel-center bg-neutral sm:rounded-box">
@@ -15,7 +15,7 @@
                 {#if recommendation.poster_path}
                     <div
                         on:click={() => routeToPage(recommendation.id, mediaType)}
-                        class="carousel-item h-96 w-64 p-1">
+                        class="carousel-item h-full w-1/2 sm:w-48 p-1">
                         <img
                             src="{IMG_URL}{recommendation.poster_path}"
                             class="rounded-lg cursor-pointer"


### PR DESCRIPTION
This makes the recommendation size better for mobile view & normal view.

![image](https://user-images.githubusercontent.com/50198099/142709270-52de539f-aa96-437a-b413-af8f10149a97.png)
![image](https://user-images.githubusercontent.com/50198099/142709279-3fecf368-e45e-4780-b86e-b05de8a8c340.png)

Furthermore it also adds logic that there needs to be atleast 5 recommendations for it to appear. This was added since the recommendations looks really off with less that this.