### PR TITLE
Full-setup not fetching newest json.gz files from tmdb

### DIFF
--- a/backend/app/api.py
+++ b/backend/app/api.py
@@ -35,15 +35,15 @@ def fetch_jsongz_files():
         directory = '../json.gz_dumps/'
         Path(directory).mkdir(exist_ok=True)
 
-        tv_url = f"http://files.tmdb.org/p/exports/tv_series_ids_{date.month}" \
-            f"_{date.day}_{date.year}.json.gz"
-        movie_url = f"http://files.tmdb.org/p/exports/movie_ids_{date.month}_" \
-            f"{date.day}_{date.year}.json.gz"
+        tv_url = f"http://files.tmdb.org/p/exports/tv_series_ids_{date.month:02d}" \
+            f"_{date.day:02d}_{date.year}.json.gz"
+        movie_url = f"http://files.tmdb.org/p/exports/movie_ids_{date.month:02d}_" \
+            f"{date.day:02d}_{date.year}.json.gz"
 
-        movie_path = f"{directory}movie_ids_{date.month}" \
-            f"_{date.day}_{date.year}.json.gz"
-        tv_path = f"{directory}tv_series_ids_{date.month}" \
-            f"_{date.day}_{date.year}.json.gz"
+        movie_path = f"{directory}movie_ids_{date.month:02d}" \
+            f"_{date.day:02d}_{date.year}.json.gz"
+        tv_path = f"{directory}tv_series_ids_{date.month:02d}" \
+            f"_{date.day:02d}_{date.year}.json.gz"
 
         movie_response = requests.get(movie_url, stream=True)
         tv_response = requests.get(tv_url, stream=True)
@@ -63,6 +63,11 @@ def fetch_jsongz_files():
                 f.write(tv_response.raw.read())
                 print(f"[{tv_path}] downloaded succesfully".replace(directory, ''))
         else:
+            # if we have tried to get data for more than 30 days we give up
+            if day >= 30:
+                print('No downloads for 30 days - giving up')
+                exit(1)
+
             print('Downloads failed - trying 1 day earlier')
             day += 1
 


### PR DESCRIPTION
### Before reporting

- [X] I have tested with the lastest _master_

### Describe the bug

Right now when we download the json.gz files in [api.py](https://github.com/streamchaser/streamchaser/blob/master/backend/app/api.py), we generate the current date, and keep going 1 day back if there are no files that current day. This works perfectly fine, but where it breaks is if the months or day is single digit. tmdb requires the request format to have 2 digits even tho the date or month only has 1 digit. 

This results in streamchaser now fails to download files multiple times, until it hits the 31 january 2021, since the format fits then.

```
❯ docker-compose exec backend python3 cli.py full-setup 500
Downloading dumps: 2022-01-18
http://files.tmdb.org/p/exports/tv_series_ids_1_18_2022.json.gz
http://files.tmdb.org/p/exports/movie_ids_1_18_2022.json.gz
Downloads failed - trying 1 day earlier
Downloading dumps: 2022-01-17
http://files.tmdb.org/p/exports/tv_series_ids_1_17_2022.json.gz
http://files.tmdb.org/p/exports/movie_ids_1_17_2022.json.gz
Downloads failed - trying 1 day earlier
Downloading dumps: 2022-01-16
http://files.tmdb.org/p/exports/tv_series_ids_1_16_2022.json.gz
http://files.tmdb.org/p/exports/movie_ids_1_16_2022.json.gz
Downloads failed - trying 1 day earlier
Downloading dumps: 2022-01-15
http://files.tmdb.org/p/exports/tv_series_ids_1_15_2022.json.gz
http://files.tmdb.org/p/exports/movie_ids_1_15_2022.json.gz
Downloads failed - trying 1 day earlier
Downloading dumps: 2022-01-14
http://files.tmdb.org/p/exports/tv_series_ids_1_14_2022.json.gz
http://files.tmdb.org/p/exports/movie_ids_1_14_2022.json.gz
Downloads failed - trying 1 day earlier
Downloading dumps: 2022-01-13
http://files.tmdb.org/p/exports/tv_series_ids_1_13_2022.json.gz
http://files.tmdb.org/p/exports/movie_ids_1_13_2022.json.gz
Downloads failed - trying 1 day earlier
Downloading dumps: 2022-01-12
http://files.tmdb.org/p/exports/tv_series_ids_1_12_2022.json.gz
http://files.tmdb.org/p/exports/movie_ids_1_12_2022.json.gz
```

### To Reproduce

1. Do a full-setup without detached logs
2. See that it will fail downloading files until 31'st january 2021

### Expected behavior

It should have the format of 2 digits dated even though the month and day is only 1 digit. 

`http://files.tmdb.org/p/exports/tv_series_ids_01_12_2022.json.gz`
`http://files.tmdb.org/p/exports/movie_ids_01_12_2022.json.gz`

### Additional context

_No response_