### PR TITLE
More info on card in detailsview

### DIFF
--- a/frontend/src/components/details/top_card.svelte
+++ b/frontend/src/components/details/top_card.svelte
@@ -25,6 +25,15 @@
         window.location.href = "/"
     }
 
+    const getFormattedRuntime = (minutes: number): string => {
+        let hours = Math.floor(minutes / 60)
+        let remainingMinutes = minutes - hours * 60
+        if (hours) {
+            return hours + 'h ' + remainingMinutes + 'm'
+        } else {
+            return remainingMinutes + 'm'
+        }
+    }
 </script>
 
 <div
@@ -50,12 +59,11 @@
                 {/if}
             </div>
             {#if releaseDate && runtime}
-                <h3><i>Runtime: {runtime} minutes</i></h3>
-                <h3 class="pb-3"><i>Release date: {releaseDate}</i></h3>
+                <h3 class="pb-3"><i>{new Date(releaseDate).getFullYear()} • {getFormattedRuntime(runtime)}</i></h3>
             {:else if releaseDate}
-                <h3 class="pb-3"><i>Release date: {releaseDate}</i></h3>
+                <h3 class="pb-3"><i>{new Date(releaseDate).getFullYear()}</i></h3>
             {:else if runtime}
-                <h3 class="pb-3"><i>Runtime: {runtime}</i></h3>
+                <h3 class="pb-3"><i>{getFormattedRuntime(runtime)}</i></h3>
             {/if}
             <ReadMore
                 currentDescriptionLength={currentOverviewLength}

--- a/frontend/src/components/details/top_card.svelte
+++ b/frontend/src/components/details/top_card.svelte
@@ -4,7 +4,7 @@
     import { currentGenres } from '../../stores/genres.js';
     import { inputQuery } from '../../stores/input.js'
 
-    const INITIAL_OVERVIEW_LENGTH: number = 500;
+    const INITIAL_OVERVIEW_LENGTH: number = 550;
     const IMG_URL: string = 'https://image.tmdb.org/t/p/original/';
 
     export let backdropPath: string
@@ -13,6 +13,9 @@
     export let overview: string
     export let genres: []
     export let providers: []
+    export let runtime: number
+    export let imdbId: string
+    export let releaseDate: string
 
     let currentOverviewLength: number = INITIAL_OVERVIEW_LENGTH;
 
@@ -36,7 +39,24 @@
             />
         </figure>
         <div class="card-body max-w-md">
-            <h2 class="card-title">{title}</h2>
+            <div class="flex justify-between">
+                <h2 class="card-title">{title}</h2>
+                {#if imdbId}
+                <a href="https://www.imdb.com/title/{imdbId}">
+                    <div class="badge badge-primary mx-2 transform hover:scale-110 cursor-pointer">
+                        IMDb
+                    </div>
+                </a>
+                {/if}
+            </div>
+            {#if releaseDate && runtime}
+                <h3><i>Runtime: {runtime} minutes</i></h3>
+                <h3 class="pb-3"><i>Release date: {releaseDate}</i></h3>
+            {:else if releaseDate}
+                <h3 class="pb-3"><i>Release date: {releaseDate}</i></h3>
+            {:else if runtime}
+                <h3 class="pb-3"><i>Runtime: {runtime}</i></h3>
+            {/if}
             <ReadMore
                 currentDescriptionLength={currentOverviewLength}
                 mediaDescription={overview}

--- a/frontend/src/routes/movie/[id].svelte
+++ b/frontend/src/routes/movie/[id].svelte
@@ -62,6 +62,9 @@
 				overview={movie.overview}
 				genres={movie.genres}
 				providers={movie.providers}
+				runtime={movie.runtime}
+				imdbId={movie.imdb_id}
+				releaseDate={movie.release_date}
 			/>
 
 			<Person cast={movie.cast}/>

--- a/frontend/src/routes/person/[id].svelte
+++ b/frontend/src/routes/person/[id].svelte
@@ -57,6 +57,9 @@
                 overview={person.biography}
                 genres={null}
                 providers={null}
+                runtime={null}
+                imdbId={null}
+                releaseDate={null}
             />
 
             <PersonMedia

--- a/frontend/src/routes/tv/[id].svelte
+++ b/frontend/src/routes/tv/[id].svelte
@@ -64,7 +64,7 @@
                 overview={tv.overview}
                 genres={tv.genres}
                 providers={tv.providers}
-                runtime={null}
+                runtime={tv.episode_run_time[0]}
                 imdbId={null}
                 releaseDate={tv.first_air_date}
             />

--- a/frontend/src/routes/tv/[id].svelte
+++ b/frontend/src/routes/tv/[id].svelte
@@ -64,6 +64,9 @@
                 overview={tv.overview}
                 genres={tv.genres}
                 providers={tv.providers}
+                runtime={null}
+                imdbId={null}
+                releaseDate={tv.first_air_date}
             />
 
             <Seasons seasons={tv.seasons} />


### PR DESCRIPTION
### Is your feature request related to a problem? Please describe.

Right now on the card in detailsview we only show `title`, `description`, `poster_path` & `genres`. We could add a lot more to the card.

### Describe the solution you'd like

I would like for movies & tv to have `release date`, `director` and maybe other interesting stuff! Be creative! 

### Describe alternatives you've considered

_No response_

### Additional context

_No response_