### PR TITLE
Better handling of media with no poster path

### DIFF
--- a/frontend/src/components/details/top_card.svelte
+++ b/frontend/src/components/details/top_card.svelte
@@ -40,6 +40,7 @@
     class="flex items-center px-4 py-10 bg-cover card bg-base-200"
     style="background-image: url(&quot;{IMG_URL}{backdropPath}&quot;);e">
     <div class="card sm:card-side bg-gray-700 bg-opacity-90 bordered text-neutral-content">
+        {#if posterPath}
         <figure class="pt-10 pr-10 pl-10 sm:p-6">
             <img
                 src="{IMG_URL}{posterPath}"
@@ -47,6 +48,16 @@
                 alt={title}
             />
         </figure>
+        {:else}
+        <figure class="pt-10 pr-10 pl-10 sm:p-6">
+            <div class="h-96 bg-primary-content object-contain sm:max-h-96 rounded-lg
+                grid place-items-center">
+                <h2 class="w-64 text-center text-black text-lg">
+                    <strong>{title}</strong>
+                </h2>
+            </div>
+        </figure>
+        {/if}
         <div class="card-body max-w-md">
             <div class="flex justify-between">
                 <h2 class="card-title">{title}</h2>

--- a/frontend/src/components/media_search.svelte
+++ b/frontend/src/components/media_search.svelte
@@ -31,12 +31,20 @@
             {#each media.hits as media, mediaIndex}
                 <a href="{mediaIdToUrlConverter(media.id)}"
                     class="card compact bordered w-auto transition duration-500 ease-in-out cursor-pointer transform hover:scale-110 m-1">
-                    <figure>
-                        <img
-                            src="{LOW_RES_IMG_URL}{media.poster_path}"
-                            alt="media poster"
-                        />
-                    </figure>
+                        {#if media.poster_path}
+                        <figure>
+                            <img
+                                src="{LOW_RES_IMG_URL}{media.poster_path}"
+                                alt="media poster"
+                            />
+                        </figure>
+                        {:else}
+                        <figure class="grid place-items-center bg-primary-content h-5/6">
+                            <h2 class="text-center text-black text-lg">
+                                <strong>{media.title}</strong>
+                            </h2>
+                        </figure>
+                        {/if}
                     {#if providerAmounts[mediaIndex] === 0}
                         <div class="card-body">
                             <p class="text-center">


### PR DESCRIPTION
### Is your feature request related to a problem? Please describe.

Right now we dont handle media with no poster path very well.

![image](https://user-images.githubusercontent.com/50198099/148314418-97fd939f-566c-4d27-b02d-cc5f9383be9e.png)
![image](https://user-images.githubusercontent.com/50198099/148314458-c7f60aa3-86a8-490a-9650-78acc59f2ed5.png)
(from searching for harry potter)


### Describe the solution you'd like

I would like to have them have a static colored background with the title of the media as text on the background. This will make it look less odd, and not loose any media.

### Describe alternatives you've considered

_No response_

### Additional context

_No response_