### PR TITLE
Fix recommendations not redirecting

### DIFF
--- a/frontend/src/components/details/recommendations.svelte
+++ b/frontend/src/components/details/recommendations.svelte
@@ -14,6 +14,7 @@
             {#each recommendations as recommendation}
                 {#if recommendation.poster_path}
                     <a href="{mediaIdToUrlConverter(recommendation.id, mediaType)}"
+                        target="_self"
                         class="carousel-item h-96 w-64 p-1">
                         <img
                             src="{IMG_URL}{recommendation.poster_path}"


### PR DESCRIPTION
So yeah, the issue is back.. Recommendations only change the url, but does not redirect. It seems that in recommendations the  `target` is not being set properly for some reason. Adding it manually fixes the issue