### PR TITLE
Rethink amount of elements on rows in index page

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -25,6 +25,7 @@
   "dependencies": {
     "@macfja/svelte-persistent-store": "^1.2.0",
     "daisyui": "^1.25.3",
+    "svelte-infinite-loading": "^1.3.8",
     "svelte-media-query": "^1.1.1",
     "svelte-select": "^4.4.7",
     "theme-change": "^2.0.2"

--- a/frontend/src/components/details/person.svelte
+++ b/frontend/src/components/details/person.svelte
@@ -6,10 +6,15 @@
 
   const LOW_RES_IMG_URL = "https://image.tmdb.org/t/p/w500/"
 
-  let castItemAmount = calculateAmountOfShownItems(
-    window.visualViewport.width,
-    [27, 24, 21, 15, 12, 9]
-  )
+  let castItemAmount = calculateAmountOfShownItems({
+    width: window.visualViewport.width,
+    xxl: 18,
+    xl: 16,
+    lg: 14,
+    md: 10,
+    sm: 12,
+    mobile: 9,
+  })
   const castItemStartAmount = castItemAmount
 </script>
 

--- a/frontend/src/components/details/person.svelte
+++ b/frontend/src/components/details/person.svelte
@@ -1,14 +1,16 @@
 <script lang="ts">
-  import { mediaIdToUrlConverter } from "../../utils"
+  import { mediaIdToUrlConverter, calculateAmountOfShownItems } from "../../utils"
   import type { Cast } from "../../types"
 
   export let cast: Cast[]
 
   const LOW_RES_IMG_URL = "https://image.tmdb.org/t/p/w500/"
-  const SHOW_BUTTON_AMOUNT = 18
-  const CAST_ITEM_START_AMOUNT = 9
 
-  let castItemAmount = 9
+  let castItemAmount = calculateAmountOfShownItems(
+    window.visualViewport.width,
+    [27, 24, 21, 15, 12, 9]
+  )
+  const castItemStartAmount = castItemAmount
 </script>
 
 {#if cast.length}
@@ -37,17 +39,9 @@
     {/each}
   </div>
   <div class="flex space-x-1 justify-center pt-5">
-    {#if castItemAmount > CAST_ITEM_START_AMOUNT}
-      <button
-        on:click={() => (castItemAmount = castItemAmount - SHOW_BUTTON_AMOUNT)}
-        class="btn"
-      >
-        Show less
-      </button>
-    {/if}
     {#if castItemAmount < cast.length}
       <button
-        on:click={() => (castItemAmount = castItemAmount + SHOW_BUTTON_AMOUNT)}
+        on:click={() => (castItemAmount += castItemStartAmount)}
         class="btn btn-primary"
       >
         Show more

--- a/frontend/src/components/details/person_media.svelte
+++ b/frontend/src/components/details/person_media.svelte
@@ -6,27 +6,26 @@
     removeDuplicates,
     sortListByPopularity,
     removeContentWithMissingImagePath,
+    getMediaTitle,
   } from "../../utils"
+  import type { Media } from "../../types"
 
   const LOW_RES_IMG_URL: string = "https://image.tmdb.org/t/p/w500/"
-  export let media: []
-  let currentMediaAmount = calculateAmountOfShownItems(
-    window.visualViewport.width,
-    [32, 28, 24, 20, 16, 10]
-  )
+  export let media: Media[]
+  let currentMediaAmount = calculateAmountOfShownItems({
+    width: window.visualViewport.width,
+    xxl: 32,
+    xl: 28,
+    lg: 24,
+    md: 20,
+    sm: 16,
+    mobile: 10,
+  })
   const mediaStartAmount = currentMediaAmount
 
   const loadMoreData = async ({ detail: { loaded } }) => {
     currentMediaAmount += mediaStartAmount
     loaded()
-  }
-
-  const getMediaTitle = media => {
-    if (media.id.charAt(0) == "m") {
-      return media.title
-    } else {
-      return media.name
-    }
   }
 
   removeDuplicates(media)
@@ -35,7 +34,7 @@
 </script>
 
 {#if media.length}
-  <h1 class="text-center text-3xl pt-5">Movies & Series</h1>
+  <h1 class="text-center text-3xl pt-5">Starred in</h1>
   <div
     class="grid grid-cols-2 2xl:grid-cols-8 xl:grid-cols-7 lg:grid-cols-6 md:grid-cols-5 sm:grid-cols-4 gap-3 p-2 pt-4"
   >

--- a/frontend/src/components/media_search.svelte
+++ b/frontend/src/components/media_search.svelte
@@ -18,7 +18,7 @@
   export let currentGenres: string[]
   export let search: Function
 
-  export const loadMoreData = async ({ detail: { loaded } }) => {
+  const loadMoreData = async ({ detail: { loaded } }) => {
     currentMediaAmount += mediaStartAmount
     await search().then(() => {
       loaded()

--- a/frontend/src/components/media_search.svelte
+++ b/frontend/src/components/media_search.svelte
@@ -4,7 +4,6 @@
   import type { Meilisearch } from "../types"
 
   const SHOWN_PROVIDERS: number = 5
-  const SHOW_BUTTON_AMOUNT: number = 21
   const IMG_URL: string = "https://image.tmdb.org/t/p/original/"
   const LOW_RES_IMG_URL: string = "https://image.tmdb.org/t/p/w500/"
 
@@ -12,6 +11,7 @@
   export let providerAmounts: number[]
   export let currentCountry: string
   export let currentProviders: string[]
+  export let showButtonAmount: number
   export let mediaStartAmount: number
   export let currentMediaAmount: number
   export let input: string
@@ -21,8 +21,8 @@
   const changeMediaAmount = (buttonElement: string) => {
     currentMediaAmount =
       buttonElement === "loadmore"
-        ? currentMediaAmount + SHOW_BUTTON_AMOUNT
-        : currentMediaAmount - SHOW_BUTTON_AMOUNT
+        ? currentMediaAmount + showButtonAmount
+        : currentMediaAmount - showButtonAmount
     search()
   }
 </script>

--- a/frontend/src/routes/index.svelte
+++ b/frontend/src/routes/index.svelte
@@ -45,7 +45,10 @@
 
   const setViewportToDefault = () => {
     viewPortWidth = window.visualViewport.width
-    currentMediaAmount = calculateAmountOfShownItems(viewPortWidth)
+    currentMediaAmount = calculateAmountOfShownItems(
+      viewPortWidth,
+      [35, 30, 25, 20, 15, 10]
+    )
     mediaStartAmount = currentMediaAmount
   }
 

--- a/frontend/src/routes/index.svelte
+++ b/frontend/src/routes/index.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { calculateAmountOfShownItems } from "../utils"
   import { variables } from "../variables.js"
   import Select from "svelte-select"
   import MediaSearch from "../components/media_search.svelte"
@@ -15,7 +16,9 @@
   const GENRE_URL = `${variables.apiPath}/genres/`
   const PROVIDER_URL = `${variables.apiPath}/providers/`
   const INPUT_TIMER = 200
-  const MEDIA_START_AMOUNT = 21
+
+  let mediaStartAmount: number
+  let currentMediaAmount: number
 
   let input = ""
   let timer: NodeJS.Timeout
@@ -23,11 +26,10 @@
   let providerAmounts: number[] = []
   let genres: Genre[]
   let activeProviders = [""]
-  let currentMediaAmount = 21
 
   // run search if we haven't received input in the last 200ms
   const debounceInput = () => {
-    currentMediaAmount = MEDIA_START_AMOUNT
+    currentMediaAmount = mediaStartAmount
     clearTimeout(timer)
     timer = setTimeout(() => {
       search()
@@ -103,6 +105,10 @@
 
   onMount(async () => {
     const inputField = document.getElementById("input-field") as HTMLInputElement
+    const VIEWPORT_WIDTH = window.visualViewport.width
+    currentMediaAmount = calculateAmountOfShownItems(VIEWPORT_WIDTH)
+    mediaStartAmount = calculateAmountOfShownItems(VIEWPORT_WIDTH)
+
     setTimeout(function () {
       inputField.select()
     }, 20)
@@ -197,7 +203,7 @@
   {providerAmounts}
   currentCountry={$currentCountry}
   currentProviders={$currentProviders}
-  mediaStartAmount={MEDIA_START_AMOUNT}
+  mediaStartAmount={mediaStartAmount}
   bind:currentMediaAmount
   {input}
   currentGenres={$currentGenres}

--- a/frontend/src/routes/index.svelte
+++ b/frontend/src/routes/index.svelte
@@ -8,6 +8,7 @@
   import { currentGenres } from "../stores/genres"
   import { inputQuery } from "../stores/input"
   import { chosenTheme } from "../stores/theme.js"
+  import { limit } from "../stores/limit.js"
   import { onMount } from "svelte"
   import DT from "daisyui/colors/themes.js"
   import type { Genre, Media, Meilisearch } from "../types"
@@ -16,6 +17,7 @@
   const GENRE_URL = `${variables.apiPath}/genres/`
   const PROVIDER_URL = `${variables.apiPath}/providers/`
   const INPUT_TIMER = 200
+  const MEDIA_START_AMOUNT = 21
 
   let mediaStartAmount: number
   let currentMediaAmount: number
@@ -29,7 +31,7 @@
 
   // run search if we haven't received input in the last 200ms
   const debounceInput = () => {
-    currentMediaAmount = mediaStartAmount
+    $limit = MEDIA_START_AMOUNT
     clearTimeout(timer)
     timer = setTimeout(() => {
       search()
@@ -58,20 +60,10 @@
     const res =
       input !== ""
         ? await fetch(
-            SEARCH_URL +
-              input +
-              "?c=" +
-              $currentCountry +
-              query +
-              `&limit=${currentMediaAmount}`
+            SEARCH_URL + input + "?c=" + $currentCountry + query + `&limit=${$limit}`
           )
         : await fetch(
-            SEARCH_URL +
-              "*" +
-              "?c=" +
-              $currentCountry +
-              query +
-              `&limit=${currentMediaAmount}`
+            SEARCH_URL + "*" + "?c=" + $currentCountry + query + `&limit=${$limit}`
           )
     $inputQuery = input
     meilisearch = await res.json()
@@ -203,8 +195,8 @@
   {providerAmounts}
   currentCountry={$currentCountry}
   currentProviders={$currentProviders}
-  mediaStartAmount={mediaStartAmount}
-  bind:currentMediaAmount
+  mediaStartAmount={MEDIA_START_AMOUNT}
+  bind:$limit
   {input}
   currentGenres={$currentGenres}
   {search}

--- a/frontend/src/routes/index.svelte
+++ b/frontend/src/routes/index.svelte
@@ -45,10 +45,15 @@
 
   const setViewportToDefault = () => {
     viewPortWidth = window.visualViewport.width
-    currentMediaAmount = calculateAmountOfShownItems(
-      viewPortWidth,
-      [35, 30, 25, 20, 15, 10]
-    )
+    currentMediaAmount = calculateAmountOfShownItems({
+      width: viewPortWidth,
+      xxl: 35,
+      xl: 30,
+      lg: 25,
+      md: 20,
+      sm: 15,
+      mobile: 10,
+    })
     mediaStartAmount = currentMediaAmount
   }
 

--- a/frontend/src/routes/index.svelte
+++ b/frontend/src/routes/index.svelte
@@ -19,15 +19,15 @@
   const INPUT_TIMER = 200
   const MEDIA_START_AMOUNT = 21
 
-  let mediaStartAmount: number
-  let currentMediaAmount: number
-
   let input = ""
   let timer: NodeJS.Timeout
   let meilisearch: Meilisearch
   let providerAmounts: number[] = []
   let genres: Genre[]
   let activeProviders = [""]
+  let viewPortWidth: number
+  let currentMediaAmount: number
+  let mediaStartAmount: number
 
   // run search if we haven't received input in the last 200ms
   const debounceInput = () => {
@@ -48,6 +48,13 @@
   const search = async () => {
     // Builds the optional query for genres
     // Example: "?g=Action&g=Comedy&g=Drama"
+
+    // Sets the width of the viewport
+    viewPortWidth = window.visualViewport.width
+    currentMediaAmount = calculateAmountOfShownItems(viewPortWidth)
+    mediaStartAmount = calculateAmountOfShownItems(viewPortWidth)
+
+    console.log(viewPortWidth, currentMediaAmount, mediaStartAmount)
     let query = ""
     for (let i = 0; i < $currentGenres.length; i++) {
       query += `&g=${$currentGenres[i].value}`
@@ -60,10 +67,20 @@
     const res =
       input !== ""
         ? await fetch(
-            SEARCH_URL + input + "?c=" + $currentCountry + query + `&limit=${$limit}`
+            SEARCH_URL +
+              input +
+              "?c=" +
+              $currentCountry +
+              query +
+              `&limit=${currentMediaAmount}`
           )
         : await fetch(
-            SEARCH_URL + "*" + "?c=" + $currentCountry + query + `&limit=${$limit}`
+            SEARCH_URL +
+              "*" +
+              "?c=" +
+              $currentCountry +
+              query +
+              `&limit=${currentMediaAmount}`
           )
     $inputQuery = input
     meilisearch = await res.json()

--- a/frontend/src/routes/person/[id].svelte
+++ b/frontend/src/routes/person/[id].svelte
@@ -1,10 +1,12 @@
 <script lang="ts">
+  import { sortListByPopularity } from "../../utils"
   import { variables } from "../../variables.js"
   import { page } from "$app/stores"
   import Error from "../../components/error.svelte"
   import TopCard from "../../components/details/top_card.svelte"
   import PersonMedia from "../../components/details/person_media.svelte"
   import Spinner from "../../components/loading/spinner.svelte"
+  import TopCard from "../../components/details/top_card.svelte"
 
   const PERSON_DETAIL_URL: string = `${variables.apiPath}/person/${$page.params.id}`
 
@@ -14,6 +16,11 @@
     for (let i = 0; i < mediaArray.length; i++) {
       mediaArray[i].id = mediaType.charAt(0) + mediaArray[i].id
     }
+  }
+
+  const getMostPopularBackdropPath = mediaList => {
+    sortListByPopularity(mediaList)
+    return mediaList[0].backdrop_path
   }
 
   const fetchPersonDetails = async () => {
@@ -43,7 +50,9 @@
   <Spinner />
 {:then person}
   <TopCard
-    backdropPath={person.movie_credits[0].backdrop_path}
+    backdropPath={getMostPopularBackdropPath(
+      person.movie_credits.concat(person.tv_credits)
+    )}
     posterPath={person.profile_path}
     title={person.name}
     overview={person.biography}

--- a/frontend/src/routes/person/[id].svelte
+++ b/frontend/src/routes/person/[id].svelte
@@ -1,27 +1,15 @@
 <script lang="ts">
-  import { sortListByPopularity } from "../../utils"
+  import { addMediaToID, getMostPopularBackdropPath } from "../../utils"
   import { variables } from "../../variables.js"
   import { page } from "$app/stores"
   import Error from "../../components/error.svelte"
   import TopCard from "../../components/details/top_card.svelte"
   import PersonMedia from "../../components/details/person_media.svelte"
   import Spinner from "../../components/loading/spinner.svelte"
-  import TopCard from "../../components/details/top_card.svelte"
 
   const PERSON_DETAIL_URL: string = `${variables.apiPath}/person/${$page.params.id}`
 
   let personName: string = "Loading..."
-
-  const addMediaToID = (mediaArray: object[], mediaType: string) => {
-    for (let i = 0; i < mediaArray.length; i++) {
-      mediaArray[i].id = mediaType.charAt(0) + mediaArray[i].id
-    }
-  }
-
-  const getMostPopularBackdropPath = mediaList => {
-    sortListByPopularity(mediaList)
-    return mediaList[0].backdrop_path
-  }
 
   const fetchPersonDetails = async () => {
     const response = await fetch(PERSON_DETAIL_URL)

--- a/frontend/src/routes/person/[id].svelte
+++ b/frontend/src/routes/person/[id].svelte
@@ -1,9 +1,4 @@
 <script lang="ts">
-  import {
-    removeContentWithMissingImagePath,
-    sortListByPopularity,
-    removeDuplicates,
-  } from "../../utils"
   import { variables } from "../../variables.js"
   import { page } from "$app/stores"
   import Error from "../../components/error.svelte"
@@ -15,20 +10,21 @@
 
   let personName: string = "Loading..."
 
+  const addMediaToID = (mediaArray: object[], mediaType: string) => {
+    for (let i = 0; i < mediaArray.length; i++) {
+      mediaArray[i].id = mediaType.charAt(0) + mediaArray[i].id
+    }
+  }
+
   const fetchPersonDetails = async () => {
     const response = await fetch(PERSON_DETAIL_URL)
 
     if (response.status == 200) {
       let jsonResponse = await response.json()
       personName = jsonResponse.name
-      removeContentWithMissingImagePath(jsonResponse.movie_credits, "poster_path")
-      removeContentWithMissingImagePath(jsonResponse.tv_credits, "poster_path")
 
-      removeDuplicates(jsonResponse.movie_credits)
-      removeDuplicates(jsonResponse.tv_credits)
-
-      sortListByPopularity(jsonResponse.movie_credits)
-      sortListByPopularity(jsonResponse.tv_credits)
+      addMediaToID(jsonResponse.movie_credits, "movie")
+      addMediaToID(jsonResponse.tv_credits, "tv")
 
       return jsonResponse
     } else {
@@ -52,15 +48,14 @@
     title={person.name}
     overview={person.biography}
     genres={null}
-    providers={null}
+    freeProviders={null}
+    flatrateProviders={null}
     runtime={null}
     imdbId={null}
     releaseDate={null}
   />
 
-  <PersonMedia media={person.movie_credits} mediaType={"movie"} title={"Movies"} />
-
-  <PersonMedia media={person.tv_credits} mediaType={"tv"} title={"Series"} />
+  <PersonMedia media={person.movie_credits.concat(person.tv_credits)} />
 {:catch error}
   <Error {error} />
 {/await}

--- a/frontend/src/stores/limit.js
+++ b/frontend/src/stores/limit.js
@@ -1,4 +1,0 @@
-import { persist, sessionStorage } from "@macfja/svelte-persistent-store"
-import { writable } from "svelte/store"
-
-export const limit = persist(writable(21), sessionStorage(), "limit")

--- a/frontend/src/stores/limit.js
+++ b/frontend/src/stores/limit.js
@@ -1,0 +1,4 @@
+import { persist, sessionStorage } from "@macfja/svelte-persistent-store"
+import { writable } from "svelte/store"
+
+export const limit = persist(writable(21), sessionStorage(), "limit")

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -2,6 +2,7 @@ export interface Genre {
   label: string
   value: string
 }
+
 export interface Provider {
   display_priority: number
   logo_path: string
@@ -22,6 +23,13 @@ export interface Media {
   specific_provider_names: string[]
   specific_providers: Provider[]
   title: string
+  backdrop_path: string
+}
+
+export interface FilmOrSeries {
+  id: string
+  name?: string
+  title?: string
 }
 
 export interface Meilisearch {
@@ -65,4 +73,14 @@ export interface Cast {
   original_name: string
   popularity: number
   profile_path: string
+}
+
+export interface ViewPort {
+  width: number
+  xxl: number
+  xl: number
+  lg: number
+  md: number
+  sm: number
+  mobile: number
 }

--- a/frontend/src/utils.ts
+++ b/frontend/src/utils.ts
@@ -65,20 +65,25 @@ export const uniqueArray = (list: object[], filterBy: string) => {
 }
 
 export const calculateAmountOfShownItems = (viewportWidth: number) => {
-  if (viewportWidth < 640) {
-    console.log("sm")
-    return 12
-  } else if (viewportWidth > 764 && viewportWidth < 768) {
-    console.log("md")
-    return 16
-  } else if (viewportWidth > 1024 && viewportWidth < 1024) {
-    console.log("lg")
-    return 20
-  } else if (viewportWidth > 1280 && viewportWidth < 1280) {
-    console.log("xl")
-    return 24
-  } else if (viewportWidth > 1536) {
+  console.log(viewportWidth)
+  if (viewportWidth >= 1536) {
     console.log("2xl")
-    return 24
+    return 35
+  } else if (viewportWidth >= 1280) {
+    console.log("xl")
+    return 30
+  } else if (viewportWidth >= 1024) {
+    console.log("lg")
+    return 25
+  } else if (viewportWidth >= 764) {
+    console.log("md")
+    return 20
+  } else if (viewportWidth >= 640) {
+    console.log("sm")
+    return 15
+  } else {
+    // Less than SM
+    console.log("less than SM")
+    return 10
   }
 }

--- a/frontend/src/utils.ts
+++ b/frontend/src/utils.ts
@@ -65,25 +65,23 @@ export const uniqueArray = (list: object[], filterBy: string) => {
 }
 
 export const calculateAmountOfShownItems = (viewportWidth: number) => {
-  console.log(viewportWidth)
   if (viewportWidth >= 1536) {
-    console.log("2xl")
+    //console.log("2xl")
     return 35
   } else if (viewportWidth >= 1280) {
-    console.log("xl")
+    //console.log("xl")
     return 30
   } else if (viewportWidth >= 1024) {
-    console.log("lg")
+    //console.log("lg")
     return 25
   } else if (viewportWidth >= 764) {
-    console.log("md")
+    //console.log("md")
     return 20
   } else if (viewportWidth >= 640) {
-    console.log("sm")
+    //console.log("sm")
     return 15
   } else {
-    // Less than SM
-    console.log("less than SM")
+    //console.log("less than SM")
     return 10
   }
 }

--- a/frontend/src/utils.ts
+++ b/frontend/src/utils.ts
@@ -64,24 +64,27 @@ export const uniqueArray = (list: object[], filterBy: string) => {
   return [...new Map(list.map(item => [item[filterBy], item])).values()]
 }
 
-export const calculateAmountOfShownItems = (viewportWidth: number) => {
+export const calculateAmountOfShownItems = (
+  viewportWidth: number,
+  amounts: number[]
+) => {
   if (viewportWidth >= 1536) {
     //console.log("2xl")
-    return 35
+    return amounts[0]
   } else if (viewportWidth >= 1280) {
     //console.log("xl")
-    return 30
+    return amounts[1]
   } else if (viewportWidth >= 1024) {
     //console.log("lg")
-    return 25
+    return amounts[2]
   } else if (viewportWidth >= 764) {
     //console.log("md")
-    return 20
+    return amounts[3]
   } else if (viewportWidth >= 640) {
     //console.log("sm")
-    return 15
+    return amounts[4]
   } else {
     //console.log("less than SM")
-    return 10
+    return amounts[5]
   }
 }

--- a/frontend/src/utils.ts
+++ b/frontend/src/utils.ts
@@ -1,5 +1,6 @@
-// Generic Javascript Functions
+import type { ViewPort, Media, FilmOrSeries } from "./types"
 
+// Generic Javascript Functions
 export const getKeyByValue = (object: {}, value: string): string => {
   return Object.keys(object).find(key => object[key] === value)
 }
@@ -10,8 +11,9 @@ export const getFixedGenreValues = (genres: {}) => {
   })
 }
 
+// TODO: This should be 2 functions to type correctly
 export const mediaIdToUrlConverter = (
-  mediaId: number,
+  mediaId: string | number,
   mediaType: string = undefined
 ) => {
   if (["movie", "tv", "person"].indexOf(mediaType) !== -1) {
@@ -33,7 +35,7 @@ export const mediaIdToUrlConverter = (
   }
 }
 
-export const removeDuplicates = (arr: object[]) => {
+export const removeDuplicates = (arr: Media[]) => {
   let unique_ids = []
   for (let i = 0; i < arr.length; i++) {
     if (unique_ids.includes(arr[i].id)) {
@@ -55,8 +57,7 @@ export const removeContentWithMissingImagePath = (list: object[], pathName: stri
   }
 }
 
-// TODO: Replace any with Media type
-export const sortListByPopularity = (list: object[]) => {
+export const sortListByPopularity = (list: Media[]) => {
   list.sort((a, b) => b.popularity - a.popularity)
 }
 
@@ -64,27 +65,38 @@ export const uniqueArray = (list: object[], filterBy: string) => {
   return [...new Map(list.map(item => [item[filterBy], item])).values()]
 }
 
-export const calculateAmountOfShownItems = (
-  viewportWidth: number,
-  amounts: number[]
-) => {
-  if (viewportWidth >= 1536) {
-    //console.log("2xl")
-    return amounts[0]
-  } else if (viewportWidth >= 1280) {
-    //console.log("xl")
-    return amounts[1]
-  } else if (viewportWidth >= 1024) {
-    //console.log("lg")
-    return amounts[2]
-  } else if (viewportWidth >= 764) {
-    //console.log("md")
-    return amounts[3]
-  } else if (viewportWidth >= 640) {
-    //console.log("sm")
-    return amounts[4]
+export const calculateAmountOfShownItems = (viewPort: ViewPort) => {
+  if (viewPort.width >= 1536) {
+    return viewPort.xxl
+  } else if (viewPort.width >= 1280) {
+    return viewPort.xl
+  } else if (viewPort.width >= 1024) {
+    return viewPort.lg
+  } else if (viewPort.width >= 764) {
+    return viewPort.md
+  } else if (viewPort.width >= 640) {
+    return viewPort.sm
   } else {
-    //console.log("less than SM")
-    return amounts[5]
+    // Less than sm
+    return viewPort.mobile
+  }
+}
+
+export const addMediaToID = (mediaArray: Media[], mediaType: string) => {
+  for (let i = 0; i < mediaArray.length; i++) {
+    mediaArray[i].id = mediaType.charAt(0) + mediaArray[i].id
+  }
+}
+
+export const getMostPopularBackdropPath = (mediaList: Media[]) => {
+  sortListByPopularity(mediaList)
+  return mediaList[0].backdrop_path
+}
+
+export const getMediaTitle = (media: FilmOrSeries) => {
+  if (media.id.charAt(0) == "m") {
+    return media.title
+  } else {
+    return media.name
   }
 }

--- a/frontend/src/utils.ts
+++ b/frontend/src/utils.ts
@@ -63,3 +63,22 @@ export const sortListByPopularity = (list: object[]) => {
 export const uniqueArray = (list: object[], filterBy: string) => {
   return [...new Map(list.map(item => [item[filterBy], item])).values()]
 }
+
+export const calculateAmountOfShownItems = (viewportWidth: number) => {
+  if (viewportWidth < 640) {
+    console.log("sm")
+    return 12
+  } else if (viewportWidth > 764 && viewportWidth < 768) {
+    console.log("md")
+    return 16
+  } else if (viewportWidth > 1024 && viewportWidth < 1024) {
+    console.log("lg")
+    return 20
+  } else if (viewportWidth > 1280 && viewportWidth < 1280) {
+    console.log("xl")
+    return 24
+  } else if (viewportWidth > 1536) {
+    console.log("2xl")
+    return 24
+  }
+}

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -85,18 +85,18 @@
     tiny-glob "^0.2.9"
 
 "@sveltejs/kit@next":
-  version "1.0.0-next.287"
-  resolved "https://registry.yarnpkg.com/@sveltejs/kit/-/kit-1.0.0-next.287.tgz#4bd1b5ae67b22eacbd693282bd08c308123000c7"
-  integrity sha512-aiCCuSpE9U8tX+29fnPfh9qHzWm8dBP7hkWvzcb1SZqbij8WXHyntUg/LXmhqlb8zKflEMLWa8iS+coqYDPmPQ==
+  version "1.0.0-next.288"
+  resolved "https://registry.yarnpkg.com/@sveltejs/kit/-/kit-1.0.0-next.288.tgz#017f2f2e9ca2ceb806ad29477bf4d9b632bedddb"
+  integrity sha512-6ky4CUFNGKoU1QV+fY2LOIB7atHdUCIMRx3pX21B2g9yZzQzkot0zHBrMMBSKF0/4Wx19PLEWrlGxlhakYmi8Q==
   dependencies:
     "@sveltejs/vite-plugin-svelte" "^1.0.0-next.32"
     sade "^1.7.4"
     vite "^2.8.0"
 
 "@sveltejs/vite-plugin-svelte@^1.0.0-next.32":
-  version "1.0.0-next.38"
-  resolved "https://registry.yarnpkg.com/@sveltejs/vite-plugin-svelte/-/vite-plugin-svelte-1.0.0-next.38.tgz#5fb7e911a27e866de5c24d5e5541afefd5ced4bc"
-  integrity sha512-epYAVZvfpiDZwB4Whe5AALk3zF5odKFf8Vx4q2tth+QuXmr0GLZ13ri02zINS6pHRCx+GjtOqCEEwMaPAfPcgQ==
+  version "1.0.0-next.39"
+  resolved "https://registry.yarnpkg.com/@sveltejs/vite-plugin-svelte/-/vite-plugin-svelte-1.0.0-next.39.tgz#b9437de18d13a475f76cf603511174cdf905b8d4"
+  integrity sha512-gnvvcAW2LK+KnUn8lKb2ypcXKwSp2K57mem5C4VNKfjxdRpM6+XwNavWwVf6otnDhz3qPYl/TKKW6/dRr6eeAw==
   dependencies:
     "@rollup/pluginutils" "^4.1.2"
     debug "^4.3.3"
@@ -374,9 +374,9 @@ dlv@^1.1.3:
   integrity sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==
 
 electron-to-chromium@^1.4.71:
-  version "1.4.73"
-  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.4.73.tgz#422f6f514315bcace9615903e4a9b6b9fa283137"
-  integrity sha512-RlCffXkE/LliqfA5m29+dVDPB2r72y2D2egMMfIy3Le8ODrxjuZNVo4NIC2yPL01N4xb4nZQLwzi6Z5tGIGLnA==
+  version "1.4.75"
+  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.4.75.tgz#d1ad9bb46f2f1bf432118c2be21d27ffeae82fdd"
+  integrity sha512-LxgUNeu3BVU7sXaKjUDD9xivocQLxFtq6wgERrutdY/yIOps3ODOZExK1jg8DTEg4U8TUCb5MLGeWFOYuxjF3Q==
 
 error-ex@^1.3.1:
   version "1.3.2"
@@ -1044,6 +1044,11 @@ svelte-hmr@^0.14.9:
   resolved "https://registry.yarnpkg.com/svelte-hmr/-/svelte-hmr-0.14.9.tgz#35f277efc789e1a6230185717347cddb2f8e9833"
   integrity sha512-bKE9+4qb4sAnA+TKHiYurUl970rjA0XmlP9TEP7K/ncyWz3m81kA4HOgmlZK/7irGK7gzZlaPDI3cmf8fp/+tg==
 
+svelte-infinite-loading@^1.3.8:
+  version "1.3.8"
+  resolved "https://registry.yarnpkg.com/svelte-infinite-loading/-/svelte-infinite-loading-1.3.8.tgz#c479938bd5ca69264fe591ffbbb013b368afe578"
+  integrity sha512-hn4o848LKd2Q+M11hiMWnfFxM1GHKVDi92HPZ1FYvfed4bEeRZL+QvFAQzhy1SACq6Si0CAJcQFUZpIYmAEnpQ==
+
 svelte-media-query@^1.1.1:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/svelte-media-query/-/svelte-media-query-1.1.2.tgz#640bd764c670f0547634bd3b2ea5cbd6d5f8c195"
@@ -1119,9 +1124,9 @@ to-regex-range@^5.0.1:
     is-number "^7.0.0"
 
 typescript@*, typescript@^4.4.4:
-  version "4.5.5"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.5.5.tgz#d8c953832d28924a9e3d37c73d729c846c5896f3"
-  integrity sha512-TCTIul70LyWe6IJWT8QSYeA54WQe8EjQFU4wY52Fasj5UKx88LNYKCgBEHcOMOrFF1rKGbD8v/xcNWVUq9SymA==
+  version "4.6.2"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.6.2.tgz#fe12d2727b708f4eef40f51598b3398baa9611d4"
+  integrity sha512-HM/hFigTBHZhLXshn9sN37H085+hQGeJHJ/X7LpBWLID/fbc2acUMfU+lGD98X81sKP+pFa9f0DZmCwB9GnbAg==
 
 util-deprecate@^1.0.2:
   version "1.0.2"
@@ -1129,9 +1134,9 @@ util-deprecate@^1.0.2:
   integrity sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=
 
 vite@^2.8.0:
-  version "2.8.4"
-  resolved "https://registry.yarnpkg.com/vite/-/vite-2.8.4.tgz#4e52a534289b7b4e94e646df2fc5556ceaa7336b"
-  integrity sha512-GwtOkkaT2LDI82uWZKcrpRQxP5tymLnC7hVHHqNkhFNknYr0hJUlDLfhVRgngJvAy3RwypkDCWtTKn1BjO96Dw==
+  version "2.8.6"
+  resolved "https://registry.yarnpkg.com/vite/-/vite-2.8.6.tgz#32d50e23c99ca31b26b8ccdc78b1d72d4d7323d3"
+  integrity sha512-e4H0QpludOVKkmOsRyqQ7LTcMUDF3mcgyNU4lmi0B5JUbe0ZxeBBl8VoZ8Y6Rfn9eFKYtdXNPcYK97ZwH+K2ug==
   dependencies:
     esbuild "^0.14.14"
     postcss "^8.4.6"


### PR DESCRIPTION
**Is your feature request related to a problem? Please describe.**
The amount of elements pr row logic is not the best ATM. 

**Describe the solution you'd like**
Right now we have 21 elements on our index page. This was the number because we would have 7 elements pr row, and then we have 3 rows. Since it is not a even number it will look ugly on mobile view half of the time. I want us to rethink how many items there should be pr row, and how many elements we should start our index page with. Furthermore we could also think about how many more items should appear when `show more` button is pressed. 
