### PR TITLE
Up MeiliSearch version to 0.25.2 - M1 support

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -54,7 +54,7 @@ services:
       - "traefik.http.routers.backend-secured.tls.certresolver=mytlschallenge"
       - "traefik.docker.network=traefik"
   search:
-    image: getmeili/meilisearch:v0.22.0
+    image: getmeili/meilisearch:v0.25.2
     restart: always
     container_name: search
     ports:


### PR DESCRIPTION
* Bumps the MeiliSearch version to 0.25.2