### PR TITLE
Add TV for the media cards that are TV on index page

### DIFF
--- a/frontend/src/components/media_search.svelte
+++ b/frontend/src/components/media_search.svelte
@@ -39,6 +39,11 @@
           class="card compact w-auto bordered bg-neutral m-1
                            shadow-md hover:contrast-75 hover:ring-2 ring-primary"
         >
+          {#if media.id.charAt(0) == "t"}
+            <div class="absolute top-0 right-0 mx-1 -mt-1 opacity-85">
+              <div class="badge badge-sm">TV</div>
+            </div>
+          {/if}
           {#if media.poster_path}
             <figure>
               <img src="{LOW_RES_IMG_URL}{media.poster_path}" alt={media.tite} />


### PR DESCRIPTION
This adds TV on the cards for TV shows. This makes it easier to locate what media is TV and what is movies.

![image](https://user-images.githubusercontent.com/50198099/152365204-59508e79-f49f-4e23-9a3a-4d1d6183e86d.png)

![image](https://user-images.githubusercontent.com/50198099/152365354-b114f4e6-4758-42c3-a6bb-4f2974631829.png)
