### PR TITLE
Add free providers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ __pycache__/
 
 # Data
 pgdata
+providers_txt
 backend/providers???.txt
 
 # Frontend

--- a/.gitignore
+++ b/.gitignore
@@ -17,7 +17,6 @@ __pycache__/
 # Data
 pgdata
 providers_txt
-backend/providers???.txt
 
 # Frontend
 *.DS_Store

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,8 +20,7 @@ repos:
     rev: 4.0.1
     hooks:
       - id: flake8
-        args: [--max-line-length=88]
-        exclude: E203,W503
+        args: [--max-line-length=88, "--ignore=E203,W503"]
 
   - repo: https://github.com/asottile/reorder_python_imports
     rev: v2.7.1

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,7 +20,8 @@ repos:
     rev: 4.0.1
     hooks:
       - id: flake8
-        args: [--max-line-length=88, --ignore=E203]
+        args: [--max-line-length=88]
+        exclude: E203,W503
 
   - repo: https://github.com/asottile/reorder_python_imports
     rev: v2.7.1

--- a/backend/app/api.py
+++ b/backend/app/api.py
@@ -158,10 +158,10 @@ async def get_movie_from_id(movie_id: int, country_code: str = "DK") -> Movie:
             imdb_id=movie.get("imdb_id"),
             runtime=movie.get("runtime"),
             flatrate_providers=get_providers(
-                "flatrate", movies.get("watch/providers"), country_code
+                "flatrate", movie.get("watch/providers"), country_code
             ),
             free_providers=get_providers(
-                "free", movies.get("watch/providers"), country_code
+                "free", movie.get("watch/providers"), country_code
             ),
             recommendations=get_recommendations(movie.get("recommendations")),
             poster_path=movie.get("poster_path"),
@@ -194,7 +194,9 @@ async def get_tv_from_id(tv_id: int, country_code: str = "DK") -> TV:
             flatrate_providers=get_providers(
                 "flatrate", tv.get("watch/providers"), country_code
             ),
-            free_providers=get_providers("free", tv.get("watch/providers"), country_code),
+            free_providers=get_providers(
+                "free", tv.get("watch/providers"), country_code
+            ),
             recommendations=get_recommendations(tv.get("recommendations")),
             poster_path=tv.get("poster_path"),
             popularity=tv.get("popularity"),

--- a/backend/app/api.py
+++ b/backend/app/api.py
@@ -157,7 +157,12 @@ async def get_movie_from_id(movie_id: int, country_code: str = "DK") -> Movie:
             genres=[genre.get("name") for genre in movie.get("genres")],
             imdb_id=movie.get("imdb_id"),
             runtime=movie.get("runtime"),
-            providers=get_providers(movie.get("watch/providers"), country_code),
+            flatrate_providers=get_providers(
+                "flatrate", movies.get("watch/providers"), country_code
+            ),
+            free_providers=get_providers(
+                "free", movies.get("watch/providers"), country_code
+            ),
             recommendations=get_recommendations(movie.get("recommendations")),
             poster_path=movie.get("poster_path"),
             cast=movie.get("credits").get("cast"),
@@ -186,7 +191,10 @@ async def get_tv_from_id(tv_id: int, country_code: str = "DK") -> TV:
             overview=tv.get("overview"),
             genres=[genre.get("name") for genre in tv.get("genres")],
             episode_run_time=tv.get("episode_run_time"),
-            providers=get_providers(tv.get("watch/providers"), country_code),
+            flatrate_providers=get_providers(
+                "flatrate", tv.get("watch/providers"), country_code
+            ),
+            free_providers=get_providers("free", tv.get("watch/providers"), country_code),
             recommendations=get_recommendations(tv.get("recommendations")),
             poster_path=tv.get("poster_path"),
             popularity=tv.get("popularity"),
@@ -237,7 +245,10 @@ def request_data(media: models.Media):
             "title": data.get(title),
             "poster_path": data.get("poster_path"),
             "popularity": data.get("popularity"),
-            "providers": get_providers(data.get("watch/providers")),
+            "flatrate_providers": get_providers(
+                "flatrate", data.get("watch/providers")
+            ),
+            "free_providers": get_providers("free", data.get("watch/providers")),
             "genres": [genre.get("name") for genre in data.get("genres")]
             if data.get("genres")
             else ["Unknown"],

--- a/backend/app/api_helpers.py
+++ b/backend/app/api_helpers.py
@@ -37,7 +37,9 @@ def unique_id(media: dict) -> str:
         return str(media.get("id"))
 
 
-def get_providers(providers: dict, country_code: str = "all") -> list[dict]:
+def get_providers(
+    provider_type: str, providers: dict, country_code: str = "all"
+) -> list[dict]:
     """Gets list of provider data for a movie from a specified country code"""
 
     try:
@@ -45,14 +47,16 @@ def get_providers(providers: dict, country_code: str = "all") -> list[dict]:
             return [
                 {country: provider}
                 for country in providers.get("results")
-                if providers.get("results").get(country).get("flatrate")
-                for provider in providers.get("results").get(country).get("flatrate")
+                if providers.get("results").get(country).get(provider_type)
+                for provider in providers.get("results").get(country).get(provider_type)
             ]
 
         return [
             provider
-            for provider in providers.get("results").get(country_code).get("flatrate")
-            if providers.get("results").get(country_code).get("flatrate")
+            for provider in providers.get("results")
+            .get(country_code)
+            .get(provider_type)
+            if providers.get("results").get(country_code).get(provider_type)
         ]
     except (AttributeError, TypeError):
         # If no providers for given country code

--- a/backend/app/db/crud.py
+++ b/backend/app/db/crud.py
@@ -46,7 +46,8 @@ def update_media_data_by_id(db: Session, media_id: str, data: dict):
     db.query(models.Media).filter_by(id=media_id).update(
         {
             "genres": data.get("genres"),
-            "providers": data.get("providers"),
+            "flatrate_providers": data.get("flatrate_providers"),
+            "free_providers": data.get("free_providers"),
             "title": data.get("title"),
             "poster_path": data.get("poster_path"),
             "popularity": data.get("popularity"),

--- a/backend/app/db/models.py
+++ b/backend/app/db/models.py
@@ -17,7 +17,8 @@ class Media(Base):
     genres = Column(postgresql.ARRAY(String), nullable=True)
     poster_path = Column(String, nullable=True)
     popularity = Column(Integer, nullable=True)
-    providers = Column(postgresql.ARRAY(JSON), nullable=True)
+    flatrate_providers = Column(postgresql.ARRAY(JSON), nullable=True)
+    free_providers = Column(postgresql.ARRAY(JSON), nullable=True)
 
 
 class Genre(Base):

--- a/backend/app/db/search.py
+++ b/backend/app/db/search.py
@@ -9,7 +9,7 @@ supported_country_codes = get_settings().supported_country_codes
 def update_index():
     for country_code in supported_country_codes:
         client.index(f"media_{country_code}").update_filterable_attributes(
-            ["genres", "specific_provider_names"]
+            ["genres", "provider_names"]
         )
 
         # Isolated the important

--- a/backend/app/routers/providers.py
+++ b/backend/app/routers/providers.py
@@ -12,4 +12,16 @@ router = APIRouter(
 async def read_all_providers(country_code):
     """Reads all the providers from providers.txt"""
     # TODO: Should live in a database instead of a .txt-file
-    return [line.rstrip() for line in open(f"providers_{country_code.upper()}.txt")]
+
+    flatrate_provders = [
+        line.rstrip()
+        for line in open(
+            f"providers_txt/flatrate/providers_{country_code.upper()}.txt"
+        )
+    ]
+    free_provders = [
+        line.rstrip()
+        for line in open(f"providers_txt/free/providers_{country_code.upper()}.txt")
+    ]
+
+    return [*flatrate_provders, *free_provders]

--- a/backend/app/routers/providers.py
+++ b/backend/app/routers/providers.py
@@ -17,9 +17,9 @@ async def read_all_providers(country_code):
         line.rstrip()
         for line in open(f"providers_txt/flatrate/providers_{country_code.upper()}.txt")
     ]
-    free_provders = [
+    free_providers = [
         line.rstrip()
         for line in open(f"providers_txt/free/providers_{country_code.upper()}.txt")
     ]
 
-    return [*flatrate_provders, *free_provders]
+    return [*flatrate_provders, *free_providers]

--- a/backend/app/routers/providers.py
+++ b/backend/app/routers/providers.py
@@ -15,9 +15,7 @@ async def read_all_providers(country_code):
 
     flatrate_provders = [
         line.rstrip()
-        for line in open(
-            f"providers_txt/flatrate/providers_{country_code.upper()}.txt"
-        )
+        for line in open(f"providers_txt/flatrate/providers_{country_code.upper()}.txt")
     ]
     free_provders = [
         line.rstrip()

--- a/backend/app/routers/search.py
+++ b/backend/app/routers/search.py
@@ -16,8 +16,7 @@ async def search(
     limit: int,
     c: str,
     g: list[str] | None = Query(None),
-    frp: list[str] = Query(None),
-    flp: list[str] = Query(None),
+    p: list[str] | None = Query(None),
 ):
     """
     # Our endpoint for the MeiliSearch API
@@ -27,28 +26,20 @@ async def search(
     * **p**: Optional provider query
     """
     genres = g
-    free_providers = frp
-    flatrate_providers = flp
+    providers = p
     country_code = c
 
-    if genres and (frp or flp):
+    if genres and providers:
         genre_list: list[str] = [f'genres="{genre}"' for genre in genres]
-        flatrate_provider_list: list[list[str]] = [
-            [
-                f'flatrate_provider_names="{providers}"'
-                for providers in flatrate_providers
-            ]
-        ]
-
-        free_provider_list: list[list[str]] = [
-            [f'free_provider_names="{providers}"' for providers in free_providers]
+        provider_list: list[list[str]] = [
+            [f'provider_names="{providers}"' for providers in providers]
         ]
 
         return client.index(f"media_{country_code}").search(
             user_input,
             {
                 "limit": limit,
-                "filter": genre_list + flatrate_provider_list + free_provider_list,
+                "filter": genre_list + provider_list,
                 "sort": ["popularity:desc"],
             },
         )
@@ -62,21 +53,14 @@ async def search(
                 "sort": ["popularity:desc"],
             },
         )
-    elif frp or flp:
+    elif providers:
         return client.index(f"media_{country_code}").search(
             user_input,
             {
                 "limit": limit,
                 # This is using OR logic
                 "filter": [
-                    [
-                        f'flatrate_provider_names="{providers}"'
-                        for providers in flatrate_providers
-                    ]
-                    + [
-                        f'free_provider_names="{providers}"'
-                        for providers in free_providers
-                    ]
+                    [f'provider_names="{providers}"' for providers in providers]
                 ],
                 "sort": ["popularity:desc"],
             },

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -12,7 +12,7 @@ class Media(BaseModel):
     genres: Any | None  # Rapand told me to do it :'( #TODO: find a proper solution
     poster_path: str | None
     popularity: int | None
-    provider_name: list[str] | None
+    provider_names: list[str] | None
     providers: list[dict] | None
 
     class Config:

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -12,9 +12,8 @@ class Media(BaseModel):
     genres: Any | None  # Rapand told me to do it :'( #TODO: find a proper solution
     poster_path: str | None
     popularity: int | None
+    provider_name: list[str] | None
     providers: list[dict] | None
-    specific_provider_names: list[str] | None
-    specific_providers: list[dict] | None
 
     class Config:
         # Makes use of database syntax "media.id" instead of "media['id']
@@ -29,7 +28,8 @@ class Movie(BaseModel):
     genres: list[str] | None
     imdb_id: str | None
     runtime: str | None
-    providers: list[dict] | None
+    flatrate_providers: list[dict] | None
+    free_providers: list[dict] | None
     recommendations: list[dict]
     poster_path: str | None
     popularity: int
@@ -44,7 +44,8 @@ class TV(BaseModel):
     overview: str
     genres: list[str] | None
     episode_run_time: list[int]
-    providers: list[dict] | None
+    flatrate_providers: list[dict] | None
+    free_providers: list[dict] | None
     recommendations: list[dict] | None
     poster_path: str | None
     popularity: int

--- a/backend/app/util.py
+++ b/backend/app/util.py
@@ -13,3 +13,7 @@ def coroutine(f):
         return asyncio.run(f(*args, **kwargs))
 
     return wrapper
+
+
+def unique_list(flatrate: list, free: list) -> list:
+    return [provider for provider in free if provider not in flatrate] + flatrate

--- a/frontend/src/components/details/top_card.svelte
+++ b/frontend/src/components/details/top_card.svelte
@@ -12,7 +12,8 @@
   export let title: string
   export let overview: string
   export let genres: []
-  export let providers: []
+  export let freeProviders: []
+  export let flatrateProviders: []
   export let runtime: number
   export let imdbId: string
   export let releaseDate: string
@@ -108,8 +109,8 @@
     </div>
   </div>
 
-  {#if providers}
-    {#if !providers.length}
+  {#if freeProviders || flatrateProviders}
+    {#if !freeProviders.length && !flatrateProviders.length}
       <div class="pt-5">
         <div class="badge badge-lg shadow-2xl">
           No providers in {$currentCountry}
@@ -117,7 +118,7 @@
       </div>
     {:else}
       <div class="sm:flex sm:justify-center grid grid-cols-4 pt-5">
-        {#each providers as provider}
+        {#each freeProviders.concat(flatrateProviders) as provider}
           <div class="avatar tooltip border-neutral" data-tip={provider.provider_name}>
             <div
               data-tip={provider.provider_name}

--- a/frontend/src/components/details/top_card.svelte
+++ b/frontend/src/components/details/top_card.svelte
@@ -118,7 +118,9 @@
       </div>
     {:else}
       <div class="sm:flex sm:justify-center grid grid-cols-4 pt-5">
-        {#each freeProviders.concat(flatrateProviders) as provider}
+        {#each [...new Map(freeProviders
+              .concat(flatrateProviders)
+              .map(item => [item["provider_id"], item])).values()] as provider}
           <div class="avatar tooltip border-neutral" data-tip={provider.provider_name}>
             <div
               data-tip={provider.provider_name}

--- a/frontend/src/components/details/top_card.svelte
+++ b/frontend/src/components/details/top_card.svelte
@@ -3,6 +3,7 @@
   import { currentCountry } from "../../stores/country.js"
   import { currentGenres } from "../../stores/genres.js"
   import { inputQuery } from "../../stores/input.js"
+  import { uniqueArray } from "../../utils"
 
   const INITIAL_OVERVIEW_LENGTH: number = 550
   const IMG_URL: string = "https://image.tmdb.org/t/p/original/"
@@ -118,9 +119,7 @@
       </div>
     {:else}
       <div class="sm:flex sm:justify-center grid grid-cols-4 pt-5">
-        {#each [...new Map(freeProviders
-              .concat(flatrateProviders)
-              .map(item => [item["provider_id"], item])).values()] as provider}
+        {#each uniqueArray(freeProviders.concat(flatrateProviders), "provider_id") as provider}
           <div class="avatar tooltip border-neutral" data-tip={provider.provider_name}>
             <div
               data-tip={provider.provider_name}

--- a/frontend/src/components/media_search.svelte
+++ b/frontend/src/components/media_search.svelte
@@ -63,7 +63,7 @@
             </div>
           {:else if providerAmounts[mediaIndex] <= SHOWN_PROVIDERS}
             <div class="-space-x-4 avatar-group">
-              {#each media.free_providers.concat(media.flatrate_providers) as provider}
+              {#each media.providers as provider}
                 <div class="avatar border-neutral-focus">
                   <div class="w-12 h-12">
                     <img src="{IMG_URL}{provider.logo_path}" alt={provider.name} />
@@ -73,9 +73,7 @@
             </div>
           {:else}
             <div class="-space-x-4 avatar-group">
-              {#each media.free_providers
-                .concat(media.flatrate_providers)
-                .slice(0, SHOWN_PROVIDERS - 1) as provider}
+              {#each media.providers.slice(0, SHOWN_PROVIDERS - 1) as provider}
                 <div class="avatar border-neutral-focus">
                   <div class="w-12 h-12">
                     <img src="{IMG_URL}{provider.logo_path}" alt={provider.name} />

--- a/frontend/src/components/media_search.svelte
+++ b/frontend/src/components/media_search.svelte
@@ -63,7 +63,7 @@
             </div>
           {:else if providerAmounts[mediaIndex] <= SHOWN_PROVIDERS}
             <div class="-space-x-4 avatar-group">
-              {#each media.specific_providers as provider}
+              {#each media.free_providers.concat(media.flatrate_providers) as provider}
                 <div class="avatar border-neutral-focus">
                   <div class="w-12 h-12">
                     <img src="{IMG_URL}{provider.logo_path}" alt={provider.name} />
@@ -73,7 +73,9 @@
             </div>
           {:else}
             <div class="-space-x-4 avatar-group">
-              {#each media.specific_providers.slice(0, SHOWN_PROVIDERS - 1) as provider}
+              {#each media.free_providers
+                .concat(media.flatrate_providers)
+                .slice(0, SHOWN_PROVIDERS - 1) as provider}
                 <div class="avatar border-neutral-focus">
                   <div class="w-12 h-12">
                     <img src="{IMG_URL}{provider.logo_path}" alt={provider.name} />

--- a/frontend/src/routes/index.svelte
+++ b/frontend/src/routes/index.svelte
@@ -36,9 +36,8 @@
   // TODO: Replace any with a Media type
   const hitProviderAmounts = (searchHits: [any]) => {
     providerAmounts = []
-    searchHits.forEach((hit) => {
-      const combinedLength = hit.flatrate_providers.length + hit.free_providers.length
-      providerAmounts.push(combinedLength)
+    searchHits.forEach(hit => {
+      providerAmounts.push(hit.providers.length)
     })
   }
 

--- a/frontend/src/routes/index.svelte
+++ b/frontend/src/routes/index.svelte
@@ -36,8 +36,9 @@
   // TODO: Replace any with a Media type
   const hitProviderAmounts = (searchHits: [any]) => {
     providerAmounts = []
-    searchHits.forEach(hit => {
-      providerAmounts.push(hit.specific_providers.length)
+    searchHits.forEach((hit) => {
+      const combinedLength = hit.flatrate_providers.length + hit.free_providers.length
+      providerAmounts.push(combinedLength)
     })
   }
 

--- a/frontend/src/routes/movie/[id].svelte
+++ b/frontend/src/routes/movie/[id].svelte
@@ -1,9 +1,5 @@
 <script lang="ts">
-  import {
-    removeContentWithMissingImagePath,
-    routeToPage,
-    sortListByPopularity,
-  } from "../../utils"
+  import { removeContentWithMissingImagePath, sortListByPopularity } from "../../utils"
   import { variables } from "../../variables.js"
   import { page } from "$app/stores"
   import { currentCountry } from "../../stores/country.js"

--- a/frontend/src/routes/movie/[id].svelte
+++ b/frontend/src/routes/movie/[id].svelte
@@ -57,7 +57,8 @@
     title={movie.title}
     overview={movie.overview}
     genres={movie.genres}
-    providers={movie.providers}
+    freeProviders={movie.free_providers}
+    flatrateProviders={movie.flatrate_providers}
     runtime={movie.runtime}
     imdbId={movie.imdb_id}
     releaseDate={movie.release_date}

--- a/frontend/src/routes/tv/[id].svelte
+++ b/frontend/src/routes/tv/[id].svelte
@@ -62,7 +62,8 @@
     title={tv.name}
     overview={tv.overview}
     genres={tv.genres}
-    providers={tv.providers}
+    freeProviders={tv.free_providers}
+    flatrateProviders={tv.flatrate_providers}
     runtime={tv.episode_run_time[0]}
     imdbId={null}
     releaseDate={tv.first_air_date}

--- a/frontend/src/utils.ts
+++ b/frontend/src/utils.ts
@@ -59,3 +59,7 @@ export const removeContentWithMissingImagePath = (list: [], pathName: string) =>
 export const sortListByPopularity = (list: [any]) => {
   list.sort((a, b) => b.popularity - a.popularity)
 }
+
+export const uniqueArray = (list: object[], filterBy: string) => {
+  return [...new Map(list.map(item => [item[filterBy], item])).values()]
+}


### PR DESCRIPTION
### Is your feature request related to a problem? Please describe.

We should be able to support free providers like `DRTV`. There are a lot of people seeking content through free providers like `viafree` and so on, and we are loosing a lot by not giving them the information they need to stream now!

### Describe the solution you'd like

right now in `api_helpers.py`, we filter for only `flatrate`, and here we could easily add `free` aswell.

```python
def get_providers(providers: Dict, country_code: str = 'all') -> List[Dict]:
    """ Gets list of provider data for a movie from a specified country code
    """

    try:
        if country_code == 'all':
            return [
                {country: provider}
                for country in providers.get('results')
                if providers.get('results').get(country).get('flatrate')
                for provider in providers.get('results').get(country).get('flatrate')
            ]

        return [
            provider
            for provider in providers.get('results').get(country_code).get('flatrate')
            if providers.get('results').get(country_code).get('flatrate')
        ]
    except (AttributeError, TypeError):
        # If no providers for given country code
        return []
```

### Describe alternatives you've considered

_No response_

### Additional context

The data structure of free look like this:

```json
{
  "id": 43795,
  "results": {
    "DK": {
      "link": "https://www.themoviedb.org/tv/43795-bamses-julerejse/watch?locale=DK",
      "free": [
        {
          "display_priority": 36,
          "logo_path": "/9DjSXKi0v3kOxZ5k3xezEqv5wSk.jpg",
          "provider_id": 620,
          "provider_name": "DRTV"
        }
      ],
      "buy": [
        {
          "display_priority": 21,
          "logo_path": "/oEntjkQyz84qo1C4FZK9jW1qznl.jpg",
          "provider_id": 423,
          "provider_name": "Blockbuster"
        }
      ]
    }
  }
}
```