### PR TITLE
The error handling site should route back to the index page, if the user is linked to a dead link from an external source

### DIFF
--- a/frontend/src/components/error.svelte
+++ b/frontend/src/components/error.svelte
@@ -1,4 +1,6 @@
 <script lang="ts">
+  import ErrorButtons from "./error_buttons.svelte"
+
   export let error
 
   console.error(error)
@@ -10,8 +12,8 @@
   <h2 class="flex justify-center">The requested site could not be reached</h2>
   <br />
   <div class="flex justify-center">
-    <button on:click={() => (window.location.href = "/")} id="goback" class="btn">
-      Back to safety
-    </button>
+    <div class="px-2">
+      <ErrorButtons />
+    </div>
   </div>
 </div>

--- a/frontend/src/components/error.svelte
+++ b/frontend/src/components/error.svelte
@@ -10,7 +10,7 @@
   <h2 class="flex justify-center">The requested site could not be reached</h2>
   <br />
   <div class="flex justify-center">
-    <button on:click={() => window.history.back()} id="goback" class="btn">
+    <button on:click={() => (window.location.href = "/")} id="goback" class="btn">
       Back to safety
     </button>
   </div>

--- a/frontend/src/components/error_buttons.svelte
+++ b/frontend/src/components/error_buttons.svelte
@@ -1,0 +1,15 @@
+<script lang="ts">
+</script>
+
+{#if window.history.length > 1}
+  <button on:click={() => window.history.back()} id="goback" class="btn btn-primary">
+    Previous Page
+  </button>
+  <button on:click={() => (window.location.href = "/")} class="btn btn-primary">
+    Home
+  </button>
+{:else}
+  <button on:click={() => (window.location.href = "/")} class="btn btn-primary">
+    Home
+  </button>
+{/if}

--- a/frontend/src/components/loading/spinner.svelte
+++ b/frontend/src/components/loading/spinner.svelte
@@ -24,7 +24,7 @@
     <br />
     <div class="flex justify-center">
       <button
-        on:click={() => window.history.back()}
+        on:click={() => (window.location.href = "/")}
         id="goback"
         class="btn btn-primary"
       >

--- a/frontend/src/components/loading/spinner.svelte
+++ b/frontend/src/components/loading/spinner.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import { onMount } from "svelte"
+  import ErrorButtons from "../error_buttons.svelte"
 
   export let timeout = true
 
@@ -23,13 +24,9 @@
     </h2>
     <br />
     <div class="flex justify-center">
-      <button
-        on:click={() => (window.location.href = "/")}
-        id="goback"
-        class="btn btn-primary"
-      >
-        Back to safety
-      </button>
+      <div class="px-2">
+        <ErrorButtons />
+      </div>
     </div>
   {/if}
 </div>


### PR DESCRIPTION
If the user has gotten a faulty link from somewhere other than streamchaser, we should route them to the index and not back to where they came from(which would be nowhere if they were linked from Discord for example)