### PR TITLE
Meilisearch data is not persistent

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -61,6 +61,8 @@ services:
     image: getmeili/meilisearch:v0.25.2
     restart: always
     container_name: search
+    volumes:
+      - meili:/data.ms
     ports:
       - 7700:7700
     networks:
@@ -134,6 +136,7 @@ networks:
     external: false
 
 volumes:
+  meili:
   pgdata:
   node_modules:
   cache:


### PR DESCRIPTION
### Before reporting

- [X] I have tested with the lastest _master_

### Describe the bug

Meilisearch data is not persistent when downing the containers

### To Reproduce

1. docker-compose down
1a. docker-compose down search  // Alternative
3. docker-compose up
4. *Meilisearch indexes are gone*

### Expected behavior

Meilisearch keeps data when downed without the `-v`

### Additional context

https://docs.meilisearch.com/learn/getting_started/quick_start.html#step-1-setup-and-installation:

> Data written to a Docker container is not persistent and is wiped every time the container is stopped. We recommend using a shared Docker volume between containers and host machines to provide persistent storage.

Similar to how it's done with the other databases at the bottom of our docker-compose.yml
```yml
volumes:
  pgdata:
  node_modules:
  cache:
    driver: local
```