### PR TITLE
No logs over API calls in production

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -15,7 +15,9 @@ FROM base as prod
 RUN echo "Starting backend as production" \
     && poetry export -f requirements.txt --output requirements.txt --without-hashes \
     && pip install --no-cache-dir -r requirements.txt
-CMD gunicorn app.main:app -k uvicorn.workers.UvicornWorker -b :80
+
+# '-' after --access-logfile means to log to stdout
+CMD gunicorn app.main:app --access-logfile - -k uvicorn.workers.UvicornWorker -b :80
 
 
 FROM base as dev


### PR DESCRIPTION
### Before reporting

- [X] I have tested with the lastest _master_

### Describe the bug

Our backend doesn't send logs to stdout with the production environment(gunicorn)

### To Reproduce

1. `docker-compose logs -f backend`
2. Go-to `localhost` and watch the logs not do anything

### Expected behavior

The same status logs as in development