### PR TITLE
Fade out transition delays page loading

### DIFF
--- a/frontend/src/components/media_search.svelte
+++ b/frontend/src/components/media_search.svelte
@@ -36,7 +36,7 @@
     {#each meilisearch.hits as media, mediaIndex}
       <a
         in:fade
-        out:fade={{ duration: 200 }}
+        out:fade|local={{ duration: 200 }}
         href={mediaIdToUrlConverter(media.id)}
         class="card compact w-auto bordered bg-neutral-focus m-1
                            shadow-md hover:contrast-75 hover:ring-2 ring-primary"

--- a/frontend/src/components/no_results.svelte
+++ b/frontend/src/components/no_results.svelte
@@ -6,36 +6,27 @@
   export let currentProviders: string[]
   export let currentGenres: Genre[]
   export let input: string
-
-  let visible = false
-
-  onMount(() => {
-    // Lets the fade transition happen before it renders
-    setTimeout(() => (visible = true), 200)
-  })
 </script>
 
-{#if visible}
-  <div in:fade={{ duration: 200 }} class="flex flex-col mt-20">
-    <div class="m-auto text-center max-w-md">
-      <p>No results for:</p>
-      <p><b><i>{input ? input : "<No input>"}</i></b></p>
-      {#if currentGenres.length > 0}
-        <p class="pt-2">Genres:</p>
-        {#each currentGenres as genre}
-          <div class="badge mx-1">{genre.label}</div>
-        {/each}
-        <p class="text-xs pt-1"><i>Consider using less genres</i></p>
-      {/if}
-      {#if currentProviders.length > 0}
-        <p class="pt-2">Providers:</p>
-        {#each currentProviders as provider}
-          <div class="badge mx-1">{provider.label}</div>
-        {/each}
-        <p class="text-xs pt-1">
-          <i>Consider adding more providers or removing all</i>
-        </p>
-      {/if}
-    </div>
+<div in:fade={{ duration: 200 }} class="flex flex-col mt-20">
+  <div class="m-auto text-center max-w-md">
+    <p>No results for:</p>
+    <p><b><i>{input ? input : "<No input>"}</i></b></p>
+    {#if currentGenres.length > 0}
+      <p class="pt-2">Genres:</p>
+      {#each currentGenres as genre}
+        <div class="badge mx-1">{genre.label}</div>
+      {/each}
+      <p class="text-xs pt-1"><i>Consider using less genres</i></p>
+    {/if}
+    {#if currentProviders.length > 0}
+      <p class="pt-2">Providers:</p>
+      {#each currentProviders as provider}
+        <div class="badge mx-1">{provider.label}</div>
+      {/each}
+      <p class="text-xs pt-1">
+        <i>Consider adding more providers or removing all</i>
+      </p>
+    {/if}
   </div>
-{/if}
+</div>


### PR DESCRIPTION
### Before reporting

- [X] I have tested with the lastest _master_

### Describe the bug

The out transition is delaying the detail page load

https://user-images.githubusercontent.com/43907402/156844556-b4c96d20-9644-4217-a3ae-6a76447a7e67.mov




### To Reproduce

1. Press a card
2. Wait 200ms for the cards to fade out

### Expected behavior

The page should load instantly

### Additional context

_No response_