### PR TITLE
Change genres to use normal aioredis and be in one key

### DIFF
--- a/backend/app/db/cache.py
+++ b/backend/app/db/cache.py
@@ -1,19 +1,11 @@
 from aioredis import from_url
-from pydantic_aioredis import Model
-from pydantic_aioredis import RedisConfig
-from pydantic_aioredis import Store
+from pydantic import BaseModel
 
 
-class Genre(Model):
-    # the _primary_key_field is mandatory
-    _primary_key_field: str = "label"
+class Genre(BaseModel):
     label: str
     value: str
 
-
-# For using Redis through Pydantic models
-store = Store(name="cache", redis_config=RedisConfig(host="redis"))
-store.register_model(Genre)
 
 # For having all the complex Redis operations
 redis = from_url("redis://redis")

--- a/backend/app/db/database_service.py
+++ b/backend/app/db/database_service.py
@@ -1,3 +1,4 @@
+import json
 from math import ceil
 from pathlib import Path
 
@@ -7,6 +8,7 @@ from app.db import crud
 from app.db import database
 from app.db import models
 from app.db.cache import Genre
+from app.db.cache import redis
 from app.db.crud import count_all_media
 from app.db.database import engine
 from app.db.models import Media
@@ -49,13 +51,13 @@ async def insert_genres_to_cache(genres: dict) -> None:
         Genre(
             label=genre,
             value=genre.replace(" & ", "%20%26%20"),
-        )
+        ).dict()
         if " & " in genre
-        else Genre(label=genre, value=genre)
+        else Genre(label=genre, value=genre).dict()
         for genre in genres.values()
     ]
 
-    await Genre.insert(fixed_genres)
+    await redis.set("genres", json.dumps(fixed_genres))
 
 
 def init_meilisearch_indexing(chunk_size: int):

--- a/backend/app/routers/genres.py
+++ b/backend/app/routers/genres.py
@@ -1,4 +1,7 @@
+import json
+
 from app.db.cache import Genre
+from app.db.cache import redis
 from fastapi import APIRouter
 
 
@@ -12,4 +15,4 @@ router = APIRouter(
 @router.get("/", response_model=list[Genre])
 async def read_all_genres():
     """Reads all genres, returns only name and value"""
-    return await Genre.select()
+    return json.loads(await redis.get("genres"))

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -17,7 +17,6 @@ fastapi = "^0.73.0"
 gunicorn = "^20.1.0"
 httpx = "^0.22.0"
 aioredis = "^2.0.1"
-pydantic-aioredis = "^0.4.3"
 pytest-asyncio = "^0.18.1"
 
 [tool.poetry.dev-dependencies]

--- a/backend/tests/test_cache.py
+++ b/backend/tests/test_cache.py
@@ -1,6 +1,6 @@
 import asyncio
+import json
 
-from app.db.cache import Genre
 from app.db.cache import redis
 from app.db.database_service import insert_genres_to_cache
 from pytest import fixture
@@ -42,13 +42,14 @@ async def test_insert_genres_to_cache():
     """
     Test that the genre cache is created and populated correctly.
     """
-    assert not await Genre.select()
+    assert not await redis.get("genres")
     await insert_genres_to_cache(test_genre_dict)
+    assert await redis.get("genres")
 
-    genres = await Genre.select()
+    genres = json.loads(await redis.get("genres"))
 
     assert genres
     assert len(genres) == 3
-    assert "&" in genres[2].label
+    assert "&" in genres[2]["label"]
     for genre in genres:
-        assert "&" not in genre.value
+        assert "&" not in genre["value"]


### PR DESCRIPTION
Removes pydantic_aioredis, because it's a bit silly to have libraries that do the same

* Changes the way we store genres to be in one JSON, instead of a key for every genre
