### PR TITLE
Fix adapter-auto and adapter-node can cooperate

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -18,6 +18,9 @@ RUN yarn install && yarn cache clean
 # Copy all local files into the image
 COPY . .
 
+# Weird hack to make both serverless and node work
+RUN mv node_svelte.config.js svelte.config.js
+
 # Expose port 3000 for the SvelteKit app and 24678 for Vite's HMR
 EXPOSE 3000
 EXPOSE 24678

--- a/frontend/node_svelte.config.js
+++ b/frontend/node_svelte.config.js
@@ -1,0 +1,21 @@
+/** @type {import('@sveltejs/kit').Config} */
+import svelte from "svelte-preprocess"
+import autoPreprocess from "svelte-preprocess"
+import sveltePreprocess from "svelte-preprocess"
+import typescript from "@rollup/plugin-typescript"
+import adapter from "@sveltejs/adapter-node"
+
+const config = {
+  kit: {
+    adapter: adapter(),
+  },
+  plugins: [
+    svelte({
+      preprocess: autoPreprocess(),
+    }),
+    typescript(),
+  ],
+  preprocess: sveltePreprocess(),
+}
+
+export default config

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -11,7 +11,8 @@
   "devDependencies": {
     "@rollup/plugin-typescript": "^8.3.0",
     "@sveltejs/adapter-auto": "next",
-    "@sveltejs/kit": "^1.0.0-next.295",
+    "@sveltejs/adapter-node": "next",
+    "@sveltejs/kit": "^1.0.0-next.299",
     "@tsconfig/svelte": "^2.0.1",
     "autoprefixer": "^10.4.2",
     "postcss": "^8.4.5",

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -107,6 +107,13 @@
     esbuild "^0.14.21"
     tiny-glob "^0.2.9"
 
+"@sveltejs/adapter-node@next":
+  version "1.0.0-next.72"
+  resolved "https://registry.yarnpkg.com/@sveltejs/adapter-node/-/adapter-node-1.0.0-next.72.tgz#e526061a62a75abf09baff318976c9870deadcb8"
+  integrity sha512-+zlZM41LgluD6MI6NE2SgPe5Qee9KZfKyYu52+YAgORg+7OPfgwdOupLVlLk6wTyAbzq5lzpNMu5/qEfnCX++Q==
+  dependencies:
+    tiny-glob "^0.2.9"
+
 "@sveltejs/adapter-vercel@1.0.0-next.46":
   version "1.0.0-next.46"
   resolved "https://registry.yarnpkg.com/@sveltejs/adapter-vercel/-/adapter-vercel-1.0.0-next.46.tgz#3852a57fadfaa4f896618afbaae90591fd7e460b"


### PR DESCRIPTION
### Before reporting

- [X] I have tested with the lastest _master_

### Describe the bug

Frontend cant find the build module because of adapter-auto looks in a different directory

### To Reproduce

1. docker-compose up --build -d frontend
2. docker-compose logs -f frontend
3. See that build module could not be found

### Expected behavior

Expected build module to be found when building the container

### Additional context

_No response_