### PR TITLE
Remove/simplify Meilisearch index batching

### DIFF
--- a/backend/app/db/database_service.py
+++ b/backend/app/db/database_service.py
@@ -92,8 +92,11 @@ def init_meilisearch_indexing():
     """MeiliSearch indexing from Postgres DB"""
     db = database.SessionLocal()
     media: list = get_all_media(db)
+    country_codes = get_settings().supported_country_codes
 
-    for country_code in tqdm(get_settings().supported_country_codes):
+    for country_code in tqdm(
+        country_codes, desc=f"Indexing {len(country_codes)} countries"
+    ):
         index_media(country_code, media)
 
 

--- a/backend/app/db/database_service.py
+++ b/backend/app/db/database_service.py
@@ -1,5 +1,4 @@
 import json
-from math import ceil
 
 from app import schemas
 from app.config import get_settings
@@ -8,9 +7,7 @@ from app.db import database
 from app.db import models
 from app.db.cache import Genre
 from app.db.cache import redis
-from app.db.crud import count_all_media
-from app.db.database import engine
-from app.db.models import Media
+from app.db.crud import get_all_media
 from app.db.search import client
 from app.util import unique_list
 from sqlalchemy.exc import IntegrityError
@@ -59,53 +56,45 @@ async def insert_genres_to_cache(genres: dict) -> None:
     await redis.set("genres", json.dumps(fixed_genres))
 
 
-def init_meilisearch_indexing(chunk_size: int):
+def index_media(country_code: str, media: list):
+    client.index(f"media_{country_code}").add_documents(
+        [
+            schemas.Media(
+                id=media.id,
+                title=media.title,
+                original_title=media.original_title,
+                overview=media.overview,
+                release_date=media.release_date,
+                genres=media.genres,
+                poster_path=media.poster_path,
+                popularity=media.popularity,
+                provider_names=[
+                    provider.get(country_code).get("provider_name")
+                    for provider in unique_list(
+                        media.flatrate_providers, media.free_providers
+                    )
+                    if provider.get(country_code)
+                ],
+                providers=[
+                    provider.get(country_code)
+                    for provider in unique_list(
+                        media.flatrate_providers, media.free_providers
+                    )
+                    if provider.get(country_code)
+                ],
+            ).dict()
+            for media in media
+        ]
+    )
+
+
+def init_meilisearch_indexing():
     """MeiliSearch indexing from Postgres DB"""
     db = database.SessionLocal()
-    all_media_length = count_all_media(db)
-    chunk_loops = ceil(all_media_length / chunk_size)  # Will always round up
+    media: list = get_all_media(db)
 
-    with engine.connect() as conn:
-        media_stream = conn.execution_options(stream_results=True).execute(
-            Media.__table__.select()
-        )
-        print(
-            f"MeiliSearch is about to index "
-            f"{len(get_settings().supported_country_codes)} countries"
-        )
-        with tqdm(total=chunk_loops, desc="Queuing up documents for indexing") as pbar:
-            while chunk := media_stream.fetchmany(chunk_size):
-                for country_code in get_settings().supported_country_codes:
-                    client.index(f"media_{country_code}").add_documents(
-                        [
-                            schemas.Media(
-                                id=media.id,
-                                title=media.title,
-                                original_title=media.original_title,
-                                overview=media.overview,
-                                release_date=media.release_date,
-                                genres=media.genres,
-                                poster_path=media.poster_path,
-                                popularity=media.popularity,
-                                provider_names=[
-                                    provider.get(country_code).get("provider_name")
-                                    for provider in unique_list(
-                                        media.flatrate_providers, media.free_providers
-                                    )
-                                    if provider.get(country_code)
-                                ],
-                                providers=[
-                                    provider.get(country_code)
-                                    for provider in unique_list(
-                                        media.flatrate_providers, media.free_providers
-                                    )
-                                    if provider.get(country_code)
-                                ],
-                            ).dict()
-                            for media in chunk
-                        ]
-                    )
-                pbar.update(1)
+    for country_code in tqdm(get_settings().supported_country_codes):
+        index_media(country_code, media)
 
 
 async def extract_unique_providers_to_cache():

--- a/backend/cli.py
+++ b/backend/cli.py
@@ -80,7 +80,7 @@ def fetch_media(popularity: float = 0):
 
 @app.command()
 def index_meilisearch():
-    init_meilisearch_indexing(chunk_size=10000)
+    init_meilisearch_indexing()
     update_index()
 
 
@@ -157,7 +157,8 @@ async def full_setup(popularity: Optional[float], remove_non_ascii: bool = False
     if remove_non_ascii:
         remove_non_ascii_media()
     add_data()
-    index_meilisearch()
+    init_meilisearch_indexing()
+    update_index()
     await extract_unique_providers_to_cache()
     update_index()
     remove_blacklisted_from_search()

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -85,6 +85,8 @@ services:
     image: getmeili/meilisearch:v0.26.0
     restart: always
     container_name: search
+    environment:
+      - MEILI_HTTP_PAYLOAD_SIZE_LIMIT=1048576000 # 1 gigabyte
     volumes:
       - meili:/data.ms
     ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -82,7 +82,7 @@ services:
       - "traefik.http.routers.rust-backend-secured.tls.certresolver=mytlschallenge"
       - "traefik.docker.network=traefik"
   search:
-    image: getmeili/meilisearch:v0.25.2
+    image: getmeili/meilisearch:v0.26.0
     restart: always
     container_name: search
     volumes:


### PR DESCRIPTION
* Removes Postgres batch-streaming
* Changes payload size from 100mb to 1gb

Makes the whole Meilisearch indexing step happen in 1-go per country, which will save Meilisearch from re-indexing
This will eat a LOT of memory, but since we got plenty it won't be an issue. 