### PR TITLE
Redo filter design

### DIFF
--- a/frontend/src/routes/index.svelte
+++ b/frontend/src/routes/index.svelte
@@ -9,7 +9,6 @@
   import { inputQuery } from "../stores/input"
   import { chosenTheme } from "../stores/theme.js"
   import { onMount } from "svelte"
-  import DT from "daisyui/colors/themes.js"
   import type { Genre, Media, Meilisearch } from "../types"
 
   const SEARCH_URL = `${PYTHON_API}/search/`
@@ -153,66 +152,6 @@
       on:input={debounceInput}
       autofocus
     />
-  </div>
-  <div
-    class="sm:grid sm:grid-cols-2 sm:gap-2 mt-2 mb-3"
-    style="
-
-             --borderRadius: var(--rounded-btn, .5rem);
-             --background: {DT[`[data-theme=${$chosenTheme}]`]['base-100']};
-             --border: 1px solid {DT[`[data-theme=${$chosenTheme}]`]['primary']};
-             --borderFocusColor: {DT[`[data-theme=${$chosenTheme}]`]['primary']};
-             --borderHoverColor: {DT[`[data-theme=${$chosenTheme}]`]['primary']};
-             --multiItemBG: {DT[`[data-theme=${$chosenTheme}]`]['primary']};
-             --multiItemColor: {DT[`[data-theme=${$chosenTheme}]`]['primary-content']};
-             --multiItemActiveBG: {DT[`[data-theme=${$chosenTheme}]`]['primary-focus']};
-             --multiItemActiveColor: {DT[`[data-theme=${$chosenTheme}]`][
-      'primary-content'
-    ]};
-             --clearSelectHoverColor: {DT[`[data-theme=${$chosenTheme}]`]['primary']};
-             --itemIsActiveBG: {DT[`[data-theme=${$chosenTheme}]`]['primary-content']};
-             --itemColor: {DT[`[data-theme=${$chosenTheme}]`]['text-secondary']};
-             --listBackground: {DT[`[data-theme=${$chosenTheme}]`]['neutral']};
-             --itemHoverBG: {DT[`[data-theme=${$chosenTheme}]`]['neutral-focus']};
-             --inputColor: {DT[`[data-theme=${$chosenTheme}]`]['text-primary']};
-              "
-  >
-    <div class="mb-2 sm:mb-0">
-      <Select
-        on:select={e => {
-          $currentGenres = e.detail ? e.detail : []
-          setViewportToDefault()
-          search()
-        }}
-        on:clear={e => {
-          $currentGenres = e.detail
-            ? $currentGenres.splice($currentGenres.indexOf(e.detail.value))
-            : []
-        }}
-        value={$currentGenres.length ? $currentGenres : null}
-        items={genres}
-        isMulti={true}
-        placeholder="Select genres..."
-      />
-    </div>
-    <div>
-      <Select
-        on:select={e => {
-          $currentProviders = e.detail ? e.detail : []
-          setViewportToDefault()
-          search()
-        }}
-        on:clear={e => {
-          $currentProviders = e.detail
-            ? $currentProviders.splice($currentProviders.indexOf(e.detail.value))
-            : []
-        }}
-        value={$currentProviders.length ? $currentProviders : null}
-        items={activeProviders}
-        isMulti={true}
-        placeholder="Select providers..."
-      />
-    </div>
   </div>
 </div>
 <MediaSearch


### PR DESCRIPTION
### Is your feature request related to a problem? Please describe.

The design of our only 2 filters is not optimal right now, and I would like multi-selects to be removed completely, since the design is not always working optimally.

### Describe the solution you'd like

I would like a drop down or a drawer with room for future filters, and put genres in there. I would like under the search bar to have a place for filtering of providers in a modern way.

- [ ] Providers have to be in dict format from backend, and use the new design  
#213
- [ ] Design for rest of the filters, this is only genres ATM

### Describe alternatives you've considered

_No response_

### Additional context

_No response_