### PR TITLE
Fix broken genre badge redirects plus sort genres

### DIFF
--- a/backend/app/db/database_service.py
+++ b/backend/app/db/database_service.py
@@ -53,6 +53,8 @@ async def insert_genres_to_cache(genres: dict) -> None:
         for genre in genres.values()
     ]
 
+    fixed_genres.sort(key=lambda genre: genre["label"])
+
     await redis.set("genres", json.dumps(fixed_genres))
 
 

--- a/frontend/src/components/details/top_card.svelte
+++ b/frontend/src/components/details/top_card.svelte
@@ -21,8 +21,9 @@
 
   let currentOverviewLength: number = INITIAL_OVERVIEW_LENGTH
 
-  const changeGenreAndRedirectHome = genre => {
-    $currentGenres = [genre]
+  const changeGenreAndRedirectHome = (genre: string) => {
+    // Needs to replace the &'s for the multiselects to find it
+    $currentGenres = [genre.replace(" & ", "%20%26%20")]
     $inputQuery = ""
     window.location.href = "/"
   }


### PR DESCRIPTION
# Description
* Fixes an issue where clicking on the badge would break the multi selecting for genres
* Sorts genres alphabetically before putting them in Redis

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
