### PR TITLE
General frontend cleanups

### DIFF
--- a/frontend/src/components/details/read_more.svelte
+++ b/frontend/src/components/details/read_more.svelte
@@ -8,7 +8,6 @@
   <p>
     {mediaDescription.slice(0, currentDescriptionLength)}
     <a
-      href=""
       class="cursor-pointer text-blue-500"
       on:click={() => (currentDescriptionLength = mediaDescription.length)}
     >

--- a/frontend/src/components/details/recommendations.svelte
+++ b/frontend/src/components/details/recommendations.svelte
@@ -23,14 +23,12 @@
 
 {#if recommendations.length}
   <h1 class="text-center text-3xl pt-5 pb-5">Recommendations</h1>
-  <div class="bg-neutral rounded-lg swiper-container">
+  <div class="bg-neutral sm:rounded-lg swiper-container">
     <Swiper
       spaceBetween={15}
       {slidesPerView}
       loop={true}
       freemode={true}
-      mousewheel={true}
-      modules={[FreeMode, Mousewheel]}
       touchEventsTarget={{ touchEventsTarget: "container" }}
     >
       {#each recommendations as recommendation}
@@ -43,7 +41,7 @@
             >
               <img
                 src="{IMG_W342}{recommendation.poster_path}"
-                class="h-80 rounded-lg hover:contrast-75 hover:ring-2 ring-primary"
+                class="h-72 w-full rounded-lg hover:contrast-75 hover:ring-2 ring-primary"
                 alt={recommendation.title}
               />
             </a>

--- a/frontend/src/components/details/seasons.svelte
+++ b/frontend/src/components/details/seasons.svelte
@@ -45,7 +45,7 @@
                 <figure>
                   <img
                     src="{IMG_W500}{season.poster_path}"
-                    class="object-fit"
+                    class="object-fit h-96"
                     alt={season.name}
                   />
                 </figure>
@@ -53,7 +53,7 @@
                 <figure>
                   <img
                     src="../../no_image_available.jpg"
-                    class="object-fit rounded-lg"
+                    class="object-fit h-72"
                     alt="No poster available"
                   />
                 </figure>
@@ -92,7 +92,7 @@
                 <figure>
                   <img
                     src="../../no_image_available.jpg"
-                    class="object-fit rounded-lg h-86"
+                    class="object-fit h-72"
                     alt="No poster available"
                   />
                 </figure>

--- a/frontend/src/components/details/seasons.svelte
+++ b/frontend/src/components/details/seasons.svelte
@@ -17,16 +17,16 @@
 
 <div class="container px-2">
   <div class="text-3xl p-4 flex justify-center">Seasons</div>
-  <div class="tabs md:flex sm:justify-center m-mx">
+  <div class="tabs flex justify-center">
     {#each seasons as season, index}
       {#if index === currentTab}
-        <div class="tab tab-bordered tab-lg tab-active">
+        <div class="tab tab-bordered tab-active">
           {season.name === "Specials"
             ? "S"
             : season.name.substr(season.name.indexOf(" ") + 1)}
         </div>
       {:else}
-        <div on:click={() => changeActiveTab(index)} class="tab tab-lg tab-bordered">
+        <div on:click={() => changeActiveTab(index)} class="tab tab-bordered">
           {season.name === "Specials"
             ? "S"
             : season.name.substr(season.name.indexOf(" ") + 1)}
@@ -45,14 +45,14 @@
                 <figure>
                   <img
                     src="{IMG_W500}{season.poster_path}"
-                    class="object-fit rounded-lg"
+                    class="object-fit"
                     alt={season.name}
                   />
                 </figure>
               {:else}
                 <figure>
                   <img
-                    src="../static/no_image_available.jpg"
+                    src="../../no_image_available.jpg"
                     class="object-fit rounded-lg"
                     alt="No poster available"
                   />
@@ -84,25 +84,25 @@
                 <figure>
                   <img
                     src="{IMG_W342}{season.poster_path}"
-                    class="object-fit rounded-lg h-96"
+                    class="object-fit h-96"
                     alt={season.name}
                   />
                 </figure>
               {:else}
                 <figure>
                   <img
-                    src="../static/no_image_available.jpg"
+                    src="../../no_image_available.jpg"
                     class="object-fit rounded-lg h-86"
                     alt="No poster available"
                   />
                 </figure>
               {/if}
               <div class="mx-4 my-2">
+                <div class="card-title">{season.name}</div>
                 <div class="text-xl text-netural-content">
                   {season.air_date ? season.air_date.split("-")[0] : "No air date"}
                   | {season.episode_count} episodes
                 </div>
-                &nbsp
                 <div class="text-lg text-netural-content">
                   {season.air_date ? `Premiered on ${season.air_date}` : "Hasn't aired"}
                 </div>

--- a/frontend/src/components/details/top_card.svelte
+++ b/frontend/src/components/details/top_card.svelte
@@ -40,7 +40,7 @@
 </script>
 
 <div
-  class="flex items-center px-4 py-10 bg-cover card bg-base-100 shadow-md"
+  class="flex items-center px-4 py-10 bg-cover card bg-base-100 rounded-none sm:rounded-lg shadow-md"
   style="background-image: url(&quot;{IMG_W1280}{backdropPath}&quot;);e"
 >
   <div

--- a/frontend/src/components/no_results.svelte
+++ b/frontend/src/components/no_results.svelte
@@ -8,7 +8,7 @@
   export let input: string
 </script>
 
-<div in:fade={{ duration: 200 }} class="flex flex-col mt-20">
+<div in:fade={{ duration: 500 }} class="flex flex-col mt-20">
   <div class="m-auto text-center max-w-md">
     <p>No results for:</p>
     <p><b><i>{input ? input : "<No input>"}</i></b></p>

--- a/frontend/src/routes/index.svelte
+++ b/frontend/src/routes/index.svelte
@@ -151,7 +151,7 @@
       class="input input-bordered input-primary"
       bind:value={input}
       on:input={debounceInput}
-      autofocus
+      autofocus={viewPortWidth <= 640 ? false : true}
     />
   </div>
   <div


### PR DESCRIPTION
This PR does the following:

- Makes `read more...` button not redirect to top with a temp solution of removing the `href`
- Makes the background of recommendations on details not be rounded when on mobile view
- Makes the size of images of recommendations more consitant
- Removes mouse wheel scroll on recommendations
- Makes top card background not rounded on mobile view
- Fixes the `image_not_available` on Season cards where there is no image. Before the image was not shown, and it always showed the `alt tag`
- Made Season tabs not be large
- Centered the Season tabs on mobile too
- Adds Season title to the card on non-mobile view
- Makes the Season image not rounded on the right side on non mobile view
- Makes Season image sizes consistant
- Add a longer fade transition for `no_results` so that it doesnt randomly appear after clicking a genre on a details view
- Removes `autofocus` on search input field on index page for mobile views