### PR TITLE
Remove multiselect border on mobile

### DIFF
--- a/frontend/src/routes/index.svelte
+++ b/frontend/src/routes/index.svelte
@@ -160,7 +160,9 @@
 
              --borderRadius: var(--rounded-btn, .5rem);
              --background: {DT[`[data-theme=${$chosenTheme}]`]['base-100']};
-             --border: 1px solid {DT[`[data-theme=${$chosenTheme}]`]['primary']};
+             --border: 1px solid {DT[`[data-theme=${$chosenTheme}]`][
+      `${viewPortWidth <= 640 ? '' : 'primary'}`
+    ]};
              --borderFocusColor: {DT[`[data-theme=${$chosenTheme}]`]['primary']};
              --borderHoverColor: {DT[`[data-theme=${$chosenTheme}]`]['primary']};
              --multiItemBG: {DT[`[data-theme=${$chosenTheme}]`]['primary']};


### PR DESCRIPTION
Makes mobile version look like this

<img src="https://media.discordapp.net/attachments/575364434222907412/994348329678942258/unknown.png?width=664&height=1169"/>

Does not change desktop view