### PR TITLE
Add filtering of media types

### DIFF
--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -55,6 +55,7 @@ class Settings(BaseSettings):
         "CH",
         "GB",
         "US",
+        "TEST",  # Used for testing
     ]
 
     # Postgres setting

--- a/backend/app/db/database_service.py
+++ b/backend/app/db/database_service.py
@@ -53,6 +53,7 @@ def index_media(country_code: str):
         medias.append(
             schemas.Media(
                 id=media.id,
+                type="movie" if media.id[0] == "m" else "tv",
                 title=media.title,
                 original_title=media.original_title,
                 overview=media.overview,

--- a/backend/app/db/search.py
+++ b/backend/app/db/search.py
@@ -6,22 +6,26 @@ client = meilisearch.Client("http://search:7700", "masterKey")
 async_client = meilisearch_python_async.Client("http://search:7700", "masterKey")
 
 
+def search_client_config(country_code: str):
+    client.index(f"media_{country_code}").update_filterable_attributes(
+        ["genres", "provider_names", "type"]
+    )
+
+    # Isolated the important
+    client.index(f"media_{country_code}").update_searchable_attributes(
+        ["original_title", "title"]
+    )
+
+    client.index(f"media_{country_code}").update_sortable_attributes(["popularity"])
+
+    # Sort is moved higher than default
+    client.index(f"media_{country_code}").update_ranking_rules(
+        ["words", "sort", "typo", "proximity", "attribute", "exactness"]
+    )
+
+
 def update_index():
     supported_country_codes = get_settings().supported_country_codes
 
     for country_code in supported_country_codes:
-        client.index(f"media_{country_code}").update_filterable_attributes(
-            ["genres", "provider_names"]
-        )
-
-        # Isolated the important
-        client.index(f"media_{country_code}").update_searchable_attributes(
-            ["original_title", "title"]
-        )
-
-        client.index(f"media_{country_code}").update_sortable_attributes(["popularity"])
-
-        # Sort is moved higher than default
-        client.index(f"media_{country_code}").update_ranking_rules(
-            ["words", "sort", "typo", "proximity", "attribute", "exactness"]
-        )
+        search_client_config(country_code=country_code)

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -3,6 +3,7 @@ from pydantic import BaseModel
 
 class Media(BaseModel):
     id: str
+    type: str
     title: str | None
     original_title: str
     overview: str | None

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -1,0 +1,84 @@
+import pytest
+from app.db.search import client
+from app.db.search import search_client_config
+
+test_data = [
+    {
+        "id": "m340102",
+        "type": "movie",
+        "title": "The New Mutants",
+        "original_title": "The New Mutants",
+        "overview": "The New Mutants overview",
+        "release_date": "2020-08-26",
+        "genres": ["Horror", "Science Fiction", "Mystery", "Action"],
+        "poster_path": "/xZNw9xxtwbEf25NYoz52KdbXHPM.jpg",
+        "popularity": 89,
+        "provider_names": ["HBO Max"],
+        "providers": [
+            {
+                "display_priority": 8,
+                "logo_path": "/Ajqyt5aNxNGjmF9uOfxArGrdf3X.jpg",
+                "provider_id": 384,
+                "provider_name": "HBO Max",
+            }
+        ],
+    },
+    {
+        "id": "m283700",
+        "type": "movie",
+        "title": "Pasolini",
+        "original_title": "Pasolini",
+        "overview": "Pasolini overview",
+        "release_date": "2014-09-25",
+        "genres": ["History", "Drama"],
+        "poster_path": "/fTtlV5ZRKkncPzr7tQyadYKZGcP.jpg",
+        "popularity": 8,
+        "provider_names": [],
+        "providers": [],
+    },
+    {
+        "id": "t205051",
+        "type": "tv",
+        "title": "Pela Estrada Fora",
+        "original_title": "Pela Estrada Fora",
+        "overview": "",
+        "release_date": "2022-06-30",
+        "genres": ["Documentary"],
+        "poster_path": "/cZwGewRof3bLIlKLfAaBeGCnahC.jpg",
+        "popularity": 3,
+        "provider_names": [],
+        "providers": [],
+    },
+    {
+        "id": "t1877",
+        "type": "tv",
+        "title": "Phineas and Ferb",
+        "original_title": "Phineas and Ferb",
+        "overview": "Phineas and Ferb overview",
+        "release_date": "2007-08-17",
+        "genres": ["Animation", "Comedy", "Family", "Sci-Fi & Fantasy"],
+        "poster_path": "/5M1KD34oDBjnmVQhdvoVNYgMugc.jpg",
+        "popularity": 64,
+        "provider_names": ["Disney Plus"],
+        "providers": [
+            {
+                "display_priority": 30,
+                "logo_path": "/7rwgEs15tFwyR9NPQ5vpzxTj19Q.jpg",
+                "provider_id": 337,
+                "provider_name": "Disney Plus",
+            }
+        ],
+    },
+]
+
+
+@pytest.fixture(scope="session", autouse=True)
+def setup_meilisearch():
+    """Session scoped fixture that prepares the MeiliSearch test index"""
+
+    search_client_config("TEST")
+    client.index("media_TEST").delete_all_documents()
+    task = client.index("media_TEST").add_documents(test_data)
+    client.wait_for_task(task["uid"])  # Makes sure the database is ready for the tests
+    yield
+    client.index("media_TEST").delete_all_documents()

--- a/backend/tests/test_filters.py
+++ b/backend/tests/test_filters.py
@@ -1,15 +1,18 @@
 from app.db.search import client
+from app.routers.search import filter_from_queries
 from tests.conftest import test_data
 
 
 class TestFilters:
     def test_no_filters(self):
-        """Tests ability to filter for movie, tv-series and maybe person later"""
+        """Baseline raw query, gets all the data"""
 
         search_results = client.index("media_TEST").search("*")
 
         assert search_results["nbHits"] == len(test_data)
 
+
+class TestTypeFilter:
     def test_type_movie(self):
         search_results = client.index("media_TEST").search(
             "*", {"filter": "type=movie"}
@@ -30,3 +33,89 @@ class TestFilters:
         )
 
         assert "movie" and "tv" in [media["type"] for media in search_results["hits"]]
+
+
+class TestFilterFromQueries:
+    """Tests the functionality of filter_from_queries()
+    which is used to turn the index page queries into a MeiliSearch filter
+    """
+
+    def test_filter_from_queries_empty(self):
+        """Empty list that shouldn't lead to any filtering"""
+
+        filter = filter_from_queries()
+        search_results = client.index("media_TEST").search("*", {"filter": filter})
+
+        assert search_results["nbHits"] == len(test_data)
+
+    def test_filter_from_queries_providers(self):
+        """Proves only 1 provider needs to match something"""
+
+        filter = filter_from_queries(providers=["Disney Plus"])
+        search_results = client.index("media_TEST").search("*", {"filter": filter})
+
+        assert search_results["nbHits"] == 1
+        assert "Disney Plus" in search_results["hits"][0]["provider_names"]
+
+        filter = filter_from_queries(providers=["Disney Plus", "HBO Max"])
+        search_results = client.index("media_TEST").search("*", {"filter": filter})
+
+        assert search_results["nbHits"] == 2
+        assert ["Disney Plus"] and ["HBO Max"] in [
+            hit["provider_names"] for hit in search_results["hits"]
+        ]
+
+    def test_filter_from_queries_genres(self):
+        """Proves all genres needs to match something"""
+
+        filter = filter_from_queries(genres=["Family"])
+        search_results = client.index("media_TEST").search("*", {"filter": filter})
+
+        assert search_results["nbHits"] == 1
+        assert "Family" in search_results["hits"][0]["genres"]
+
+        filter = filter_from_queries(genres=["Family", "Not a real genre"])
+        search_results = client.index("media_TEST").search("*", {"filter": filter})
+
+        assert search_results["nbHits"] == 0
+
+    def test_filter_from_queries_types(self):
+        """Proves only 1 type needs to match something"""
+
+        filter = filter_from_queries(types=["movie", "tv"])
+        search_results = client.index("media_TEST").search("*", {"filter": filter})
+
+        assert search_results["nbHits"] == len(test_data)
+        assert "movie" and "tv" in [media["type"] for media in search_results["hits"]]
+
+        filter = filter_from_queries(types=["movie"])
+        search_results = client.index("media_TEST").search("*", {"filter": filter})
+
+        assert "movie" in [media["type"] for media in search_results["hits"]]
+        assert "tv" not in [media["type"] for media in search_results["hits"]]
+
+    def test_filter_from_queries_all_queries(self):
+        """Tests for unexpected behavior when applying multiple filters"""
+
+        filter = filter_from_queries(
+            providers=["HBO Max"], genres=["Action", "Horror"], types=["movie", "tv"]
+        )
+        search_results = client.index("media_TEST").search("*", {"filter": filter})
+
+        assert search_results["nbHits"] == 1
+        assert "HBO Max" in search_results["hits"][0]["provider_names"]
+        assert "Action" and "Horror" in search_results["hits"][0]["genres"]
+
+        filter = filter_from_queries(
+            providers=["HBO Max"], genres=["A genre that isnt there"]
+        )
+        search_results = client.index("media_TEST").search("*", {"filter": filter})
+
+        assert search_results["nbHits"] == 0
+
+        filter = filter_from_queries(
+            providers=["A provider that isnt there"], genres=["Action"]
+        )
+        search_results = client.index("media_TEST").search("*", {"filter": filter})
+
+        assert search_results["nbHits"] == 0

--- a/backend/tests/test_filters.py
+++ b/backend/tests/test_filters.py
@@ -1,0 +1,32 @@
+from app.db.search import client
+from tests.conftest import test_data
+
+
+class TestFilters:
+    def test_no_filters(self):
+        """Tests ability to filter for movie, tv-series and maybe person later"""
+
+        search_results = client.index("media_TEST").search("*")
+
+        assert search_results["nbHits"] == len(test_data)
+
+    def test_type_movie(self):
+        search_results = client.index("media_TEST").search(
+            "*", {"filter": "type=movie"}
+        )
+
+        assert "movie" in [media["type"] for media in search_results["hits"]]
+        assert "tv" not in [media["type"] for media in search_results["hits"]]
+
+    def test_type_tv(self):
+        search_results = client.index("media_TEST").search("*", {"filter": "type=tv"})
+
+        assert "tv" in [media["type"] for media in search_results["hits"]]
+        assert "movie" not in [media["type"] for media in search_results["hits"]]
+
+    def test_type_movie_and_tv(self):
+        search_results = client.index("media_TEST").search(
+            "*", {"filter": [["type=movie", "type=tv"]]}
+        )
+
+        assert "movie" and "tv" in [media["type"] for media in search_results["hits"]]


### PR DESCRIPTION
# Description

* Adds the ability to filter movies/tv and only get one of them
* Refactor of the old search endpoint logic - It's a lot more scalable now
* A bunch of tests and some things that will make it easier to add more

Fixes #40 to some extent - The issue is very vague

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
