### PR TITLE
Fix indicator icon going out of screen on mobile

### DIFF
--- a/frontend/src/components/filters.svelte
+++ b/frontend/src/components/filters.svelte
@@ -18,7 +18,10 @@
 
 <div class="indicator">
   {#if filterAmount}
-    <span class="indicator-item badge badge-secondary">{filterAmount}</span>
+    <span
+      class="indicator-item indicator-top sm:indicator-end indicator-center badge badge-secondary"
+      >{filterAmount}</span
+    >
   {/if}
   <div class="dropdown dropdown-end" on:focusout={handleDropdownFocusLost}>
     <label tabindex="0" class="btn btn-primary ml-2" on:click={handleDropdownClick}>


### PR DESCRIPTION
# Description

This fixes that the indicator goes out of mobile and makes the screen draggable to the sides.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
