### PR TITLE
feat: get providers images through the cached proxy

### DIFF
--- a/frontend/src/lib/variables.js
+++ b/frontend/src/lib/variables.js
@@ -5,7 +5,7 @@ export const IMG_W185 = "https://image.tmdb.org/t/p/w185/"
 export const IMG_W342 = `${PYTHON_API}/image?size=w342&path=`
 export const IMG_W500 = "https://image.tmdb.org/t/p/w500/"
 export const IMG_W1280 = "https://image.tmdb.org/t/p/w1280/"
-export const IMG_ORIGINAL = "https://image.tmdb.org/t/p/original/"
+export const IMG_ORIGINAL = `${PYTHON_API}/image?size=original&path=`
 
 export const COUNTRIES = [
   { name: "Argentina", value: "AR", icon: "🇦🇷" },


### PR DESCRIPTION
# Description

- Uses the new cached proxy for provider images

Fixes #

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
