### PR TITLE
feat: only show media with providers when no input

### DIFF
--- a/frontend/src/routes/+page.svelte
+++ b/frontend/src/routes/+page.svelte
@@ -77,15 +77,16 @@
 
     if ($filters.tvChecked && $filters.movieChecked) {
     } else if ($filters.movieChecked) {
-      query += `&t=movie`
+      query += "&t=movie"
     } else {
-      query += `&t=tv`
+      query += "&t=tv"
     }
 
     if (!$filters.showNoProviders) {
-      query += `&only_providers=true`
+      query += "&only_providers=true"
     }
     // Searches for all(*) if empty input
+    // Empty input will only return media with providers
     const res =
       input !== ""
         ? await fetch(
@@ -102,7 +103,8 @@
               "?c=" +
               $currentCountry +
               query +
-              `&limit=${currentMediaAmount}`
+              `&limit=${currentMediaAmount}` +
+              "&only_providers=true"
           )
     $inputQuery = input
     meilisearch = await res.json()


### PR DESCRIPTION
# Description

- Changes behavior of no input to not show media with no providers
- Changes some unnecessary formatted strings to normal string that annoyed me(yay a nanosecond more performant)

I've had this requested a few times

Fixes #137 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
