### PR TITLE
fix: multiselect is uwing wront itemcolor

### DIFF
--- a/frontend/src/routes/+page.svelte
+++ b/frontend/src/routes/+page.svelte
@@ -186,7 +186,7 @@
              --multiItemActiveColor: hsl(var(--bc));
              --clearSelectHoverColor: hsl(var(--pf));
              --itemIsActiveBG: hsl(var(--pc));
-             --itemColor: hsl(var(--sc));
+             --itemColor: hsl(var(--nc));
              --listBackground: hsl(var(--n));
              --itemHoverBG: hsl(var(--p));
              --itemHoverColor: hsl(var(--pc));


### PR DESCRIPTION
# Description

Makes themes usable again with correct itemColor

Fixes #

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
