### PR TITLE
feat: change cookiedisclaimer to include options for cookies

### DIFF
--- a/frontend/src/app.html
+++ b/frontend/src/app.html
@@ -8,22 +8,6 @@
       data-domains="streamchaser.tv"
       src="https://umami.streamchaser.tv/umami.js"
     ></script>
-    <!-- Global site tag (gtag.js) - Google Analytics -->
-    <script
-      async
-      src="https://www.googletagmanager.com/gtag/js?id=G-TTQ0NCGTQQ"
-    ></script>
-    <script>
-      const host = window.location.hostname
-      if (host == "streamchaser.tv") {
-        window.dataLayer = window.dataLayer || []
-        function gtag() {
-          dataLayer.push(arguments)
-        }
-        gtag("js", new Date())
-        gtag("config", "G-TTQ0NCGTQQ")
-      }
-    </script>
     <meta charset="utf-8" />
     <link rel="icon" href="/favicon.png" />
     <meta

--- a/frontend/src/lib/components/cookie_disclaimer.svelte
+++ b/frontend/src/lib/components/cookie_disclaimer.svelte
@@ -1,9 +1,43 @@
 <script lang="ts">
+  import {
+    cookieDisclaimer,
+    allowedCookies,
+    allowNecessaryCookies,
+  } from "$lib/stores/cookies"
+  import type { CookieSelection } from "$lib/stores/cookies"
   import { fade, fly } from "svelte/transition"
-  import { cookieDisclaimer } from "$lib/stores/cookies"
   import { onMount } from "svelte"
+  import { browser } from "$app/environment"
 
-  let loadDisclaimer = false
+  const cookieDisclaimerTabs = ["Consent", "Options"]
+
+  let currentTab = 0
+  let loadDisclaimer: boolean = true
+  let allowSelection: boolean
+  let cookieSelection: CookieSelection = {
+    allowMarketing: true,
+    allowPreference: true,
+    allowAnalytical: true,
+  }
+
+  $: allowSelection = Object.values(cookieSelection).some(value => value === false)
+  $: if (browser && !$allowedCookies) {
+    localStorage.clear()
+  }
+
+  const setCookieConsent = () => {
+    $cookieDisclaimer = true
+    if (Object.values(cookieSelection).some(value => value === true)) {
+      allowedCookies.subscribe(value => {
+        if (browser) {
+          localStorage.setItem("allowedCookies", JSON.stringify(value))
+        }
+      })
+      $allowedCookies = cookieSelection
+    } else {
+      $allowNecessaryCookies = true
+    }
+  }
 
   onMount(async () => {
     setTimeout(() => (loadDisclaimer = true), 100)
@@ -13,29 +47,97 @@
 {#if loadDisclaimer}
   {#if !$cookieDisclaimer}
     <div class="flex justify-center z-50" in:fade out:fly={{ y: 200, duration: 1000 }}>
-      <div class="alert shadow fixed sm:bottom-2 bottom-0 max-w-2xl">
+      <div class="alert flex-col shadow fixed sm:bottom-2 bottom-0 max-w-2xl">
         <div class="flex flex-col">
-          <h4 class="flex justify-center pb-1">
+          <h4 class="flex justify-center">
             <b>🍪 Cookies on Streamchaser</b>
           </h4>
-          <p class="pb-2">
-            We use cookies to improve your experience. We save your country and chosen
-            providers, and store this data for your next visit. For convenience during
-            your session we keep your genres and input. We use third-party cookies to
-            enhance the experience and our service, and to analyse the use of our site.
-            Your continued browsing means that you have understood and accepted this.
-          </p>
+          <div class="tabs flex justify-center">
+            {#each cookieDisclaimerTabs as tab, index}
+              {#if index === currentTab}
+                <div class="tab tab-bordered tab-active">{tab}</div>
+              {:else}
+                <div
+                  class="tab tab-bordered"
+                  on:click={() => (currentTab = index)}
+                  on:keypress={() => (currentTab = index)}
+                >
+                  {tab}
+                </div>
+              {/if}
+            {/each}
+          </div>
+          {#if cookieDisclaimerTabs[currentTab] === "Consent"}
+            <div class="flex flex-col mb-4">
+              <p class="pb-2">
+                We use cookies to improve your experience. We save your country and
+                chosen providers, and store this data for your next visit. For
+                convenience during your session we keep your genres and input. We use
+                third-party cookies to enhance the experience and our service, and to
+                analyse the use of our site. By clicking 'Allow All' you consent to our
+                use of cookies. In the 'Options'-tab above you can manage the types of
+                data you will allow us to store.
+              </p>
+            </div>
+          {:else}
+            <div class="flex flex-col mb-4">
+              <div class="form-control">
+                <label class="label cursor-pointer">
+                  <span class="label-text text-xl">Statistics</span>
+                  <input
+                    type="checkbox"
+                    class="toggle"
+                    bind:checked={cookieSelection.allowAnalytical}
+                    on:change={!cookieSelection.allowAnalytical}
+                  />
+                </label>
+                <div class="pl-2">
+                  Statistical cookies give us insight into how you interact with our
+                  site - which pages you visit and the functionality you make use of.
+                </div>
+                <label class="label cursor-pointer">
+                  <span class="label-text text-xl">Preferences</span>
+                  <input
+                    type="checkbox"
+                    class="toggle"
+                    bind:checked={cookieSelection.allowPreference}
+                    on:change={!cookieSelection.allowPreference}
+                  />
+                </label>
+                <div class="pl-2">
+                  Preference cookies are used to remember your selected providers,
+                  country and the theme you have chosen.
+                </div>
+                <label class="label cursor-pointer">
+                  <span class="label-text text-xl">Marketing</span>
+                  <input
+                    type="checkbox"
+                    class="toggle"
+                    bind:checked={cookieSelection.allowMarketing}
+                    on:change={!cookieSelection.allowMarketing}
+                  />
+                </label>
+                <div class="pl-2">
+                  Marketing cookies are used to track you across websites. The intent is
+                  to provide you with ads that are relevant to you specifically.
+                </div>
+                <label class="label cursor-pointer">
+                  <span class="label-text text-xl">Necessary</span>
+                  <input type="checkbox" class="toggle" disabled checked />
+                </label>
+                <div class="pl-2">
+                  Necessary cookies are used in order to make the site function
+                  properly, and enable navigation and access to areas of the website.
+                </div>
+              </div>
+            </div>
+          {/if}
           <div class="flex justify-center">
-            <a
-              href="https://www.cookiesandyou.com/about-cookies/"
-              target="_blank"
-              rel="noreferrer"
-            >
-              <button class="btn btn-sm btn-ghost mr-2">About cookies</button>
+            <a href="https://www.cookiesandyou.com/about-cookies/" target="_blank">
+              <button class="btn btn-sm btn-ghost mr-2">About</button>
             </a>
-            <button
-              class="btn btn-sm btn-primary"
-              on:click={() => ($cookieDisclaimer = true)}>Accept</button
+            <button class="btn btn-sm btn-primary" on:click={setCookieConsent}
+              >{allowSelection ? "Allow Selected Cookies" : "Allow Cookies"}</button
             >
           </div>
         </div>

--- a/frontend/src/lib/components/cookie_disclaimer.svelte
+++ b/frontend/src/lib/components/cookie_disclaimer.svelte
@@ -5,17 +5,17 @@
     allowNecessaryCookies,
   } from "$lib/stores/cookies"
   import type { CookieType } from "$lib/stores/cookies"
-  import { fade, fly, slide } from "svelte/transition"
+  import { fade, fly } from "svelte/transition"
   import { onMount } from "svelte"
   import { browser } from "$app/environment"
-  import { cookieSelection, necessary, preferences, statistical } from "$lib/cookies"
+  import { cookieSelection, necessary, preferences } from "$lib/cookies"
 
   const cookieDisclaimerTabs = ["Consent", "Options"]
 
   let currentTab = 0
   let loadDisclaimer = true
   let allowSelection: boolean
-  let cookieTypes: CookieType[] = [necessary, preferences, statistical]
+  let cookieTypes: CookieType[] = [necessary, preferences]
 
   $: allowSelection = Object.values(cookieSelection).some(value => value === false)
 
@@ -44,7 +44,11 @@
 
 {#if loadDisclaimer}
   {#if !$cookieDisclaimer}
-    <div class="flex justify-center z-50" in:fade out:fly={{ y: 200, duration: 1000 }}>
+    <div
+      class="flex justify-center z-50"
+      in:fade={{ duration: 500 }}
+      out:fly={{ y: 200, duration: 1000 }}
+    >
       <div class="alert flex-col shadow fixed sm:bottom-2 bottom-0 max-w-2xl ">
         <div class="flex flex-col">
           <h4 class="flex justify-center">
@@ -66,7 +70,7 @@
             {/each}
           </div>
           {#if cookieDisclaimerTabs[currentTab] === "Consent"}
-            <div in:slide={{ duration: 1000 }} class="flex flex-col mb-4">
+            <div class="flex flex-col mb-4">
               <p class="pb-2">
                 We use cookies to improve your experience. We save your country and
                 chosen providers, and store this data for your next visit. For
@@ -80,7 +84,7 @@
               </p>
             </div>
           {:else}
-            <div in:slide={{ duration: 100000 }} class="flex flex-col mb-4">
+            <div class="flex flex-col mb-4">
               <div class="form-control">
                 {#each cookieTypes as cookieType}
                   <label class="label cursor-pointer">
@@ -90,7 +94,6 @@
                         type="checkbox"
                         class="toggle"
                         bind:checked={cookieSelection[cookieType.type]}
-                        on:change={!cookieSelection[cookieType.type]}
                       />
                     {:else}
                       <input type="checkbox" class="toggle" disabled checked />

--- a/frontend/src/lib/components/cookie_disclaimer.svelte
+++ b/frontend/src/lib/components/cookie_disclaimer.svelte
@@ -4,24 +4,22 @@
     allowedCookies,
     allowNecessaryCookies,
   } from "$lib/stores/cookies"
-  import type { CookieSelection } from "$lib/stores/cookies"
+  import type { CookieType } from "$lib/stores/cookies"
   import { fade, fly } from "svelte/transition"
   import { onMount } from "svelte"
   import { browser } from "$app/environment"
+  import { cookieSelection, necessary, preferences, statistical } from "$lib/cookies"
 
   const cookieDisclaimerTabs = ["Consent", "Options"]
 
   let currentTab = 0
   let loadDisclaimer: boolean = true
   let allowSelection: boolean
-  let cookieSelection: CookieSelection = {
-    allowMarketing: true,
-    allowPreference: true,
-    allowAnalytical: true,
-  }
+  let cookieTypes: CookieType[] = [statistical, preferences, necessary]
 
   $: allowSelection = Object.values(cookieSelection).some(value => value === false)
-  $: if (browser && !$allowedCookies) {
+
+  $: if (browser && !localStorage.getItem("allowedCookies")) {
     localStorage.clear()
   }
 
@@ -82,53 +80,24 @@
           {:else}
             <div class="flex flex-col mb-4">
               <div class="form-control">
-                <label class="label cursor-pointer">
-                  <span class="label-text text-xl">Statistics</span>
-                  <input
-                    type="checkbox"
-                    class="toggle"
-                    bind:checked={cookieSelection.allowAnalytical}
-                    on:change={!cookieSelection.allowAnalytical}
-                  />
-                </label>
-                <div class="pl-2">
-                  Statistical cookies give us insight into how you interact with our
-                  site - which pages you visit and the functionality you make use of.
-                </div>
-                <label class="label cursor-pointer">
-                  <span class="label-text text-xl">Preferences</span>
-                  <input
-                    type="checkbox"
-                    class="toggle"
-                    bind:checked={cookieSelection.allowPreference}
-                    on:change={!cookieSelection.allowPreference}
-                  />
-                </label>
-                <div class="pl-2">
-                  Preference cookies are used to remember your selected providers,
-                  country and the theme you have chosen.
-                </div>
-                <label class="label cursor-pointer">
-                  <span class="label-text text-xl">Marketing</span>
-                  <input
-                    type="checkbox"
-                    class="toggle"
-                    bind:checked={cookieSelection.allowMarketing}
-                    on:change={!cookieSelection.allowMarketing}
-                  />
-                </label>
-                <div class="pl-2">
-                  Marketing cookies are used to track you across websites. The intent is
-                  to provide you with ads that are relevant to you specifically.
-                </div>
-                <label class="label cursor-pointer">
-                  <span class="label-text text-xl">Necessary</span>
-                  <input type="checkbox" class="toggle" disabled checked />
-                </label>
-                <div class="pl-2">
-                  Necessary cookies are used in order to make the site function
-                  properly, and enable navigation and access to areas of the website.
-                </div>
+                {#each cookieTypes as cookieType}
+                  <label class="label cursor-pointer">
+                    <span class="label-text text-xl">{cookieType.name}</span>
+                    {#if cookieType.type != null}
+                      <input
+                        type="checkbox"
+                        class="toggle"
+                        bind:checked={cookieSelection[cookieType.type]}
+                        on:change={!cookieSelection[cookieType.type]}
+                      />
+                    {:else}
+                      <input type="checkbox" class="toggle" disabled checked />
+                    {/if}
+                  </label>
+                  <div class="pl-2">
+                    {cookieType.description}
+                  </div>
+                {/each}
               </div>
             </div>
           {/if}

--- a/frontend/src/lib/components/cookie_disclaimer.svelte
+++ b/frontend/src/lib/components/cookie_disclaimer.svelte
@@ -5,7 +5,7 @@
     allowNecessaryCookies,
   } from "$lib/stores/cookies"
   import type { CookieType } from "$lib/stores/cookies"
-  import { fade, fly } from "svelte/transition"
+  import { fade, fly, slide } from "svelte/transition"
   import { onMount } from "svelte"
   import { browser } from "$app/environment"
   import { cookieSelection, necessary, preferences, statistical } from "$lib/cookies"
@@ -13,9 +13,9 @@
   const cookieDisclaimerTabs = ["Consent", "Options"]
 
   let currentTab = 0
-  let loadDisclaimer: boolean = true
+  let loadDisclaimer = true
   let allowSelection: boolean
-  let cookieTypes: CookieType[] = [statistical, preferences, necessary]
+  let cookieTypes: CookieType[] = [necessary, preferences, statistical]
 
   $: allowSelection = Object.values(cookieSelection).some(value => value === false)
 
@@ -45,7 +45,7 @@
 {#if loadDisclaimer}
   {#if !$cookieDisclaimer}
     <div class="flex justify-center z-50" in:fade out:fly={{ y: 200, duration: 1000 }}>
-      <div class="alert flex-col shadow fixed sm:bottom-2 bottom-0 max-w-2xl">
+      <div class="alert flex-col shadow fixed sm:bottom-2 bottom-0 max-w-2xl ">
         <div class="flex flex-col">
           <h4 class="flex justify-center">
             <b>🍪 Cookies on Streamchaser</b>
@@ -66,19 +66,21 @@
             {/each}
           </div>
           {#if cookieDisclaimerTabs[currentTab] === "Consent"}
-            <div class="flex flex-col mb-4">
+            <div in:slide={{ duration: 1000 }} class="flex flex-col mb-4">
               <p class="pb-2">
                 We use cookies to improve your experience. We save your country and
                 chosen providers, and store this data for your next visit. For
                 convenience during your session we keep your genres and input. We use
                 third-party cookies to enhance the experience and our service, and to
-                analyse the use of our site. By clicking 'Allow All' you consent to our
-                use of cookies. In the 'Options'-tab above you can manage the types of
-                data you will allow us to store.
+                analyse the use of our site. Your continued browsing means you have
+                accepted any cookies necessary for our site to function properly. By
+                clicking 'Allow All' you consent to any other types of cookies we make
+                use of. In the 'Options'-tab above you can configure which types of data
+                you will allow us to store. Click 'About' to learn more about cookies.
               </p>
             </div>
           {:else}
-            <div class="flex flex-col mb-4">
+            <div in:slide={{ duration: 100000 }} class="flex flex-col mb-4">
               <div class="form-control">
                 {#each cookieTypes as cookieType}
                   <label class="label cursor-pointer">
@@ -102,7 +104,11 @@
             </div>
           {/if}
           <div class="flex justify-center">
-            <a href="https://www.cookiesandyou.com/about-cookies/" target="_blank">
+            <a
+              href="https://www.cookiesandyou.com/about-cookies/"
+              target="_blank"
+              rel="noreferrer"
+            >
               <button class="btn btn-sm btn-ghost mr-2">About</button>
             </a>
             <button class="btn btn-sm btn-primary" on:click={setCookieConsent}

--- a/frontend/src/lib/components/country_locator.svelte
+++ b/frontend/src/lib/components/country_locator.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import { onMount } from "svelte"
   import { currentCountry, confirmedCountry } from "$lib/stores/preferences"
+  import { allowedCookies } from "$lib/stores/cookies"
   import { PYTHON_API } from "$lib/variables"
 
   let hasError = false
@@ -29,7 +30,7 @@
 
   onMount(async () => {
     // Will only look for the country of new users
-    if (!$confirmedCountry) {
+    if ($allowedCookies && $allowedCookies.allowPreference && !$confirmedCountry) {
       await lookupCountry()
     }
   })

--- a/frontend/src/lib/components/country_locator.svelte
+++ b/frontend/src/lib/components/country_locator.svelte
@@ -1,8 +1,8 @@
 <script lang="ts">
-  import { onMount } from "svelte"
   import { currentCountry, confirmedCountry } from "$lib/stores/preferences"
   import { allowedCookies } from "$lib/stores/cookies"
   import { PYTHON_API } from "$lib/variables"
+  import { browser } from "$app/environment"
 
   let hasError = false
   let errorMsg: string
@@ -28,12 +28,9 @@
       })
   }
 
-  onMount(async () => {
-    // Will only look for the country of new users
-    if ($allowedCookies && $allowedCookies.allowPreference && !$confirmedCountry) {
-      await lookupCountry()
-    }
-  })
+  $: if (browser && $allowedCookies && $allowedCookies.allowPreference) {
+    lookupCountry()
+  }
 </script>
 
 {#if hasError}

--- a/frontend/src/lib/components/details/recommendations.svelte
+++ b/frontend/src/lib/components/details/recommendations.svelte
@@ -11,7 +11,6 @@
   import { lookupMedia } from "$lib/utils"
 
   export let recommendations: Recommendation[]
-  export let mediaType: string
 
   let loadedPage: boolean
 

--- a/frontend/src/lib/cookies.ts
+++ b/frontend/src/lib/cookies.ts
@@ -9,25 +9,21 @@ export const statistical: CookieType = {
   type: "allowStatistical",
   description:
     "Statistical cookies give us insight into how you interact with our site - which pages you visit and the functionality you make use of.",
-  cookieAmount: 1,
 }
 export const preferences: CookieType = {
   name: "Preferences",
   type: "allowPreference",
   description:
     "Preference cookies are used to remember your selected providers, country and the theme you have chosen.",
-  cookieAmount: 6,
 }
 export const marketing: CookieType = {
   name: "Marketing",
   type: "allowMarketing",
   description:
     "Marketing cookies are used to track you across websites. The intent is to provide you with ads that are relevant to you specifically.",
-  cookieAmount: 0,
 }
 export const necessary: CookieType = {
   name: "Necessary",
   description:
     "Necessary cookies are used in order to make the site function properly, and enable navigation and access to areas of the website.",
-  cookieAmount: 4,
 }

--- a/frontend/src/lib/cookies.ts
+++ b/frontend/src/lib/cookies.ts
@@ -1,0 +1,33 @@
+import type { CookieSelection, CookieType } from "$lib/stores/cookies"
+
+export const cookieSelection: CookieSelection = {
+  allowPreference: true,
+  allowStatistical: true,
+}
+export const statistical: CookieType = {
+  name: "Statistical",
+  type: "allowStatistical",
+  description:
+    "Statistical cookies give us insight into how you interact with our site - which pages you visit and the functionality you make use of.",
+  cookieAmount: 1,
+}
+export const preferences: CookieType = {
+  name: "Preferences",
+  type: "allowPreference",
+  description:
+    "Preference cookies are used to remember your selected providers, country and the theme you have chosen.",
+  cookieAmount: 6,
+}
+export const marketing: CookieType = {
+  name: "Marketing",
+  type: "allowMarketing",
+  description:
+    "Marketing cookies are used to track you across websites. The intent is to provide you with ads that are relevant to you specifically.",
+  cookieAmount: 0,
+}
+export const necessary: CookieType = {
+  name: "Necessary",
+  description:
+    "Necessary cookies are used in order to make the site function properly, and enable navigation and access to areas of the website.",
+  cookieAmount: 4,
+}

--- a/frontend/src/lib/cookies.ts
+++ b/frontend/src/lib/cookies.ts
@@ -2,7 +2,6 @@ import type { CookieSelection, CookieType } from "$lib/stores/cookies"
 
 export const cookieSelection: CookieSelection = {
   allowPreference: true,
-  allowStatistical: true,
 }
 export const statistical: CookieType = {
   name: "Statistical",

--- a/frontend/src/lib/stores/cookies.ts
+++ b/frontend/src/lib/stores/cookies.ts
@@ -2,9 +2,15 @@ import { browser } from "$app/environment"
 import { writable } from "svelte/store"
 
 export interface CookieSelection {
-  allowMarketing: boolean
   allowPreference: boolean
-  allowAnalytical: boolean
+  allowStatistical: boolean
+}
+
+export interface CookieType {
+  name: string
+  type?: string
+  description: string
+  cookieAmount: number
 }
 
 export const allowNecessaryCookies = writable<boolean>(

--- a/frontend/src/lib/stores/cookies.ts
+++ b/frontend/src/lib/stores/cookies.ts
@@ -10,7 +10,6 @@ export interface CookieType {
   name: string
   type?: string
   description: string
-  cookieAmount: number
 }
 
 export const allowNecessaryCookies = writable<boolean>(

--- a/frontend/src/lib/stores/cookies.ts
+++ b/frontend/src/lib/stores/cookies.ts
@@ -3,7 +3,6 @@ import { writable } from "svelte/store"
 
 export interface CookieSelection {
   allowPreference: boolean
-  allowStatistical: boolean
 }
 
 export interface CookieType {

--- a/frontend/src/lib/stores/cookies.ts
+++ b/frontend/src/lib/stores/cookies.ts
@@ -1,12 +1,32 @@
 import { browser } from "$app/environment"
 import { writable } from "svelte/store"
 
+export interface CookieSelection {
+  allowMarketing: boolean
+  allowPreference: boolean
+  allowAnalytical: boolean
+}
+
+export const allowNecessaryCookies = writable<boolean>(
+  (browser && sessionStorage.allowNecessaryCookies) || false
+)
+
+allowNecessaryCookies.subscribe(value => {
+  if (browser) {
+    sessionStorage.allowNecessaryCookies = String(value)
+  }
+})
+
+export const allowedCookies = writable<CookieSelection>()
+
+// true if user has allowed cookies or allowed necessary, false if not
 export const cookieDisclaimer = writable<boolean>(
-  (browser && localStorage.cookieDisclaimer) || false
+  (browser && localStorage.allowedCookies != null) ||
+    (browser && sessionStorage.allowNecessaryCookies === "true")
 )
 
 cookieDisclaimer.subscribe(value => {
   if (browser) {
-    localStorage.cookieDisclaimer = String(value)
+    sessionStorage.cookieDisclaimer = String(value)
   }
 })

--- a/frontend/src/lib/stores/preferences.ts
+++ b/frontend/src/lib/stores/preferences.ts
@@ -1,6 +1,5 @@
 import { writable } from "svelte/store"
 import { browser } from "$app/environment"
-import { setDefaultCountry } from "$lib/utils"
 import type { Genre } from "$lib/generated"
 
 export const currentGenres = writable<Genre[]>(
@@ -62,7 +61,9 @@ export const chosenTheme = writable<string>(
   (browser && localStorage.chosenTheme) || "dark"
 )
 
-export const currentCountry = writable<string>(setDefaultCountry())
+export const currentCountry = writable<string>(
+  (browser && localStorage.currentCountry) || "DK"
+)
 
 export const confirmedCountry = writable<boolean>(
   (browser && localStorage.confirmedCountry) || false

--- a/frontend/src/lib/stores/preferences.ts
+++ b/frontend/src/lib/stores/preferences.ts
@@ -27,11 +27,11 @@ export const currentProviders = writable<Provider[]>(
     : []
 )
 
-currentProviders.subscribe(value => {
-  if (browser) {
-    localStorage.setItem("currentProviders", JSON.stringify(value))
-  }
-})
+// currentProviders.subscribe(value => {
+//   if (browser && allowPreference) {
+//     localStorage.setItem("currentProviders", JSON.stringify(value))
+//   }
+// })
 
 interface Sorting {
   by: {
@@ -47,11 +47,11 @@ export const sorting = writable<Sorting>(
     : { by: { popularity: false, releaseDate: false }, asc: false }
 )
 
-sorting.subscribe(value => {
-  if (browser) {
-    localStorage.setItem("sorting", JSON.stringify(value))
-  }
-})
+// sorting.subscribe(value => {
+//   if (browser && allowPreference) {
+//     localStorage.setItem("sorting", JSON.stringify(value))
+//   }
+// })
 
 interface Filters {
   tvChecked: boolean
@@ -74,19 +74,19 @@ export const chosenTheme = writable<string>(
   (browser && localStorage.chosenTheme) || "dark"
 )
 
-chosenTheme.subscribe(value => {
-  if (browser) {
-    localStorage.chosenTheme = value
-  }
-})
+// chosenTheme.subscribe(value => {
+//   if (browser && allowPreference) {
+//     localStorage.chosenTheme = value
+//   }
+// })
 
 export const currentCountry = writable<string>(setDefaultCountry())
 
-currentCountry.subscribe(value => {
-  if (browser) {
-    localStorage.currentCountry = value
-  }
-})
+// currentCountry.subscribe(value => {
+//   if (browser && allowPreference) {
+//     localStorage.currentCountry = value
+//   }
+// })
 
 export const confirmedCountry = writable<boolean>(
   (browser && localStorage.confirmedCountry) || false

--- a/frontend/src/lib/stores/preferences.ts
+++ b/frontend/src/lib/stores/preferences.ts
@@ -27,12 +27,6 @@ export const currentProviders = writable<Provider[]>(
     : []
 )
 
-// currentProviders.subscribe(value => {
-//   if (browser && allowPreference) {
-//     localStorage.setItem("currentProviders", JSON.stringify(value))
-//   }
-// })
-
 interface Sorting {
   by: {
     popularity: boolean
@@ -46,12 +40,6 @@ export const sorting = writable<Sorting>(
     ? JSON.parse(localStorage.getItem("sorting"))
     : { by: { popularity: false, releaseDate: false }, asc: false }
 )
-
-// sorting.subscribe(value => {
-//   if (browser && allowPreference) {
-//     localStorage.setItem("sorting", JSON.stringify(value))
-//   }
-// })
 
 interface Filters {
   tvChecked: boolean
@@ -74,19 +62,7 @@ export const chosenTheme = writable<string>(
   (browser && localStorage.chosenTheme) || "dark"
 )
 
-// chosenTheme.subscribe(value => {
-//   if (browser && allowPreference) {
-//     localStorage.chosenTheme = value
-//   }
-// })
-
 export const currentCountry = writable<string>(setDefaultCountry())
-
-// currentCountry.subscribe(value => {
-//   if (browser && allowPreference) {
-//     localStorage.currentCountry = value
-//   }
-// })
 
 export const confirmedCountry = writable<boolean>(
   (browser && localStorage.confirmedCountry) || false

--- a/frontend/src/lib/utils.ts
+++ b/frontend/src/lib/utils.ts
@@ -1,4 +1,3 @@
-import { browser } from "$app/environment"
 import type { Provider, Hit, Meilisearch } from "$lib/generated"
 import type { ViewPort, Media, FilmOrSeries, Recommendation } from "$lib/types"
 import { PYTHON_API } from "$lib/variables"
@@ -134,25 +133,4 @@ export const lookupMedia = async (
   const providerAmounts = hitProviderAmounts(json.hits, country)
 
   return { meilisearch: json, providerAmounts: providerAmounts }
-}
-
-export const isJsonString = (str: string) => {
-  try {
-    JSON.parse(str)
-  } catch (e) {
-    return false
-  }
-  return true
-}
-
-// NOTE: delete in like a week? this is a hack for now :^)
-export const setDefaultCountry = () => {
-  if (browser && localStorage.currentCountry) {
-    if (isJsonString(localStorage.currentCountry)) {
-      return JSON.parse(localStorage.currentCountry)
-    }
-    return localStorage.currentCountry
-  }
-
-  return "DK"
 }

--- a/frontend/src/routes/+layout.svelte
+++ b/frontend/src/routes/+layout.svelte
@@ -8,6 +8,29 @@
   import MediaQuery from "svelte-media-query"
   import CountryLocator from "$lib/components/country_locator.svelte"
   import type { PageData } from "./$types"
+  import { allowedCookies } from "$lib/stores/cookies.js"
+  import {
+    currentCountry,
+    currentProviders,
+    sorting,
+    chosenTheme,
+  } from "$lib/stores/preferences"
+  import { browser } from "$app/environment"
+
+  $: if (browser && $allowedCookies && $allowedCookies.allowPreference) {
+    currentProviders.subscribe(value => {
+      localStorage.setItem("currentProviders", JSON.stringify(value))
+    })
+    sorting.subscribe(value => {
+      localStorage.setItem("sorting", JSON.stringify(value))
+    })
+    chosenTheme.subscribe(value => {
+      localStorage.chosenTheme = value
+    })
+    currentCountry.subscribe(value => {
+      localStorage.currentCountry = value
+    })
+  }
 
   export let data: PageData
 </script>

--- a/frontend/src/routes/+page.svelte
+++ b/frontend/src/routes/+page.svelte
@@ -12,29 +12,12 @@
     inputQuery,
     filters,
     sorting,
-    chosenTheme,
   } from "$lib/stores/preferences"
   import { onMount } from "svelte"
   import type { Meilisearch } from "$lib/generated"
   import type { PageData } from "./$types"
   import { invalidateAll } from "$app/navigation"
   import { browser } from "$app/environment"
-  import { allowedCookies } from "$lib/stores/cookies.js"
-
-  $: if (browser && $allowedCookies && $allowedCookies.allowPreference) {
-    currentProviders.subscribe(value => {
-      localStorage.setItem("currentProviders", JSON.stringify(value))
-    })
-    sorting.subscribe(value => {
-      localStorage.setItem("sorting", JSON.stringify(value))
-    })
-    chosenTheme.subscribe(value => {
-      localStorage.chosenTheme = value
-    })
-    currentCountry.subscribe(value => {
-      localStorage.currentCountry = value
-    })
-  }
 
   export let data: PageData
 

--- a/frontend/src/routes/+page.svelte
+++ b/frontend/src/routes/+page.svelte
@@ -12,12 +12,29 @@
     inputQuery,
     filters,
     sorting,
+    chosenTheme,
   } from "$lib/stores/preferences"
   import { onMount } from "svelte"
   import type { Meilisearch } from "$lib/generated"
   import type { PageData } from "./$types"
   import { invalidateAll } from "$app/navigation"
   import { browser } from "$app/environment"
+  import { allowedCookies } from "$lib/stores/cookies.js"
+
+  $: if (browser && $allowedCookies && $allowedCookies.allowPreference) {
+    currentProviders.subscribe(value => {
+      localStorage.setItem("currentProviders", JSON.stringify(value))
+    })
+    sorting.subscribe(value => {
+      localStorage.setItem("sorting", JSON.stringify(value))
+    })
+    chosenTheme.subscribe(value => {
+      localStorage.chosenTheme = value
+    })
+    currentCountry.subscribe(value => {
+      localStorage.currentCountry = value
+    })
+  }
 
   export let data: PageData
 

--- a/frontend/src/routes/movie/[id]/+page.svelte
+++ b/frontend/src/routes/movie/[id]/+page.svelte
@@ -37,4 +37,4 @@
 
 <Person cast={data.movie.cast} />
 
-<Recommendations recommendations={data.movie.recommendations} mediaType={"movie"} />
+<Recommendations recommendations={data.movie.recommendations} />

--- a/frontend/src/routes/tv/[id]/+page.svelte
+++ b/frontend/src/routes/tv/[id]/+page.svelte
@@ -40,4 +40,4 @@
 
 <Person cast={data.tv.cast} />
 
-<Recommendations recommendations={data.tv.recommendations} mediaType={"tv"} />
+<Recommendations recommendations={data.tv.recommendations} />


### PR DESCRIPTION
# Description

Extends the CookieDisclaimer-component with options for disabling certain types of cookies.
Any store using LocalStorage will wait until consent is given before being initialized.
Clears LocalStorage if cookie consent is missing.

Fixes #298

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
