### PR TITLE
fix: missing quotation marks on stores of type string

### DIFF
--- a/frontend/src/lib/stores/preferences.ts
+++ b/frontend/src/lib/stores/preferences.ts
@@ -68,7 +68,7 @@ export const chosenTheme = writable<string>(
 
 chosenTheme.subscribe(value => {
   if (browser) {
-    localStorage.chosenTheme = value
+    localStorage.chosenTheme = JSON.stringify(value)
   }
 })
 
@@ -78,7 +78,7 @@ export const currentCountry = writable<string>(
 
 currentCountry.subscribe(value => {
   if (browser) {
-    localStorage.currentCountry = value
+    localStorage.currentCountry = JSON.stringify(value)
   }
 })
 


### PR DESCRIPTION
# Description

Quotation marks around store values of type string are kept when updating value in browser

Fixes #394

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
