### PR TITLE
feat: add command to remove stale media 

### DIFF
--- a/backend/cli.py
+++ b/backend/cli.py
@@ -119,7 +119,7 @@ async def full_setup(
     await providers_to_redis()
     await countries_to_redis()
     remove_blacklisted_from_search()
-    await remove_stale_media() # TODO: remove when it is it's own cronjob
+    await remove_stale_media()  # TODO: remove when it is it's own cronjob
 
 
 @app.command()

--- a/backend/cli.py
+++ b/backend/cli.py
@@ -119,7 +119,7 @@ async def full_setup(
     await providers_to_redis()
     await countries_to_redis()
     remove_blacklisted_from_search()
-    await remove_stale_media()
+    await remove_stale_media() # TODO: remove when it is it's own cronjob
 
 
 @app.command()

--- a/backend/cli.py
+++ b/backend/cli.py
@@ -10,6 +10,7 @@ from app.db.cache import redis
 from app.db.database_service import countries_to_redis
 from app.db.database_service import insert_genres_to_cache
 from app.db.database_service import providers_to_redis
+from app.db.database_service import remove_stale_media
 from app.db.search import client
 from app.db.search import search_client_config
 from app.util import chunkify
@@ -51,7 +52,10 @@ def update_media(
         fetch_media_ids(popularity) if first_time else fetch_changed_media_ids()
     )
 
-    print(f"\nAbout to update {len(movie_ids)} movies and {len(tv_ids)} TV shows")
+    print(
+        f"\nAbout to update {len(movie_ids)} movies and {len(tv_ids)} TV shows"
+        f" in chunks of {chunk_size}"
+    )
 
     with httpx.Client(http2=True, timeout=60) as client:
         for media in zip(["movies", "tv shows"], [movie_ids, tv_ids]):
@@ -62,6 +66,12 @@ def update_media(
                 desc=f"Updating {media[0]}",
             ):
                 client.post("http://internal:8888/update-media", json={"ids": id_chunk})
+
+
+@app.command()
+@coroutine
+async def clear_stale_media_from_search(days_for_expiry: int = 3):
+    await remove_stale_media(days_for_expiry)
 
 
 @app.command()
@@ -109,6 +119,7 @@ async def full_setup(
     await providers_to_redis()
     await countries_to_redis()
     remove_blacklisted_from_search()
+    await remove_stale_media()
 
 
 @app.command()

--- a/backend/poetry.lock
+++ b/backend/poetry.lock
@@ -1,10 +1,10 @@
 [[package]]
 name = "aiofiles"
-version = "0.8.0"
+version = "22.1.0"
 description = "File support for asyncio."
 category = "main"
 optional = false
-python-versions = ">=3.6,<4.0"
+python-versions = ">=3.7,<4.0"
 
 [[package]]
 name = "anyio"
@@ -47,7 +47,7 @@ tests_no_zope = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>
 
 [[package]]
 name = "camel-converter"
-version = "1.0.7"
+version = "3.0.0"
 description = "Converts a string from snake case to camel case or camel case to snake case"
 category = "main"
 optional = false
@@ -61,7 +61,7 @@ pydantic = ["pydantic (>=1.8.2)"]
 
 [[package]]
 name = "certifi"
-version = "2022.9.24"
+version = "2022.12.7"
 description = "Python package for providing Mozilla's CA Bundle."
 category = "main"
 optional = false
@@ -98,18 +98,15 @@ optional = false
 python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*,!=3.6.*,>=2.7"
 
 [[package]]
-name = "deprecated"
-version = "1.2.13"
-description = "Python @deprecated decorator to deprecate old python classes, functions or methods."
+name = "exceptiongroup"
+version = "1.0.4"
+description = "Backport of PEP 654 (exception groups)"
 category = "main"
 optional = false
-python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
-
-[package.dependencies]
-wrapt = ">=1.10,<2"
+python-versions = ">=3.7"
 
 [package.extras]
-dev = ["tox", "bump2version (<1)", "sphinx (<2)", "importlib-metadata (<3)", "importlib-resources (<4)", "configparser (<5)", "sphinxcontrib-websupport (<2)", "zipp (<2)", "PyTest (<5)", "PyTest-Cov (<2.6)", "pytest", "pytest-cov"]
+test = ["pytest (>=6)"]
 
 [[package]]
 name = "fastapi"
@@ -145,11 +142,11 @@ tornado = ["tornado (>=0.2)"]
 
 [[package]]
 name = "h11"
-version = "0.12.0"
+version = "0.14.0"
 description = "A pure-Python, bring-your-own-I/O implementation of HTTP/1.1"
 category = "main"
 optional = false
-python-versions = ">=3.6"
+python-versions = ">=3.7"
 
 [[package]]
 name = "h2"
@@ -173,16 +170,16 @@ python-versions = ">=3.6.1"
 
 [[package]]
 name = "httpcore"
-version = "0.15.0"
+version = "0.16.2"
 description = "A minimal low-level HTTP client."
 category = "main"
 optional = false
 python-versions = ">=3.7"
 
 [package.dependencies]
-anyio = ">=3.0.0,<4.0.0"
+anyio = ">=3.0,<5.0"
 certifi = "*"
-h11 = ">=0.11,<0.13"
+h11 = ">=0.13,<0.15"
 sniffio = ">=1.0.0,<2.0.0"
 
 [package.extras]
@@ -191,7 +188,7 @@ socks = ["socksio (>=1.0.0,<2.0.0)"]
 
 [[package]]
 name = "httpx"
-version = "0.23.0"
+version = "0.23.1"
 description = "The next generation HTTP client."
 category = "main"
 optional = false
@@ -200,13 +197,13 @@ python-versions = ">=3.7"
 [package.dependencies]
 certifi = "*"
 h2 = {version = ">=3,<5", optional = true, markers = "extra == \"http2\""}
-httpcore = ">=0.15.0,<0.16.0"
+httpcore = ">=0.15.0,<0.17.0"
 rfc3986 = {version = ">=1.3,<2", extras = ["idna2008"]}
 sniffio = "*"
 
 [package.extras]
-brotli = ["brotlicffi", "brotli"]
-cli = ["click (>=8.0.0,<9.0.0)", "rich (>=10,<13)", "pygments (>=2.0.0,<3.0.0)"]
+brotli = ["brotli", "brotlicffi"]
+cli = ["click (>=8.0.0,<9.0.0)", "pygments (>=2.0.0,<3.0.0)", "rich (>=10,<13)"]
 http2 = ["h2 (>=3,<5)"]
 socks = ["socksio (>=1.0.0,<2.0.0)"]
 
@@ -248,7 +245,7 @@ requests = "*"
 
 [[package]]
 name = "meilisearch-python-async"
-version = "0.28.1"
+version = "0.29.1"
 description = "A Python async client for the Meilisearch API"
 category = "main"
 optional = false
@@ -263,14 +260,11 @@ PyJWT = ">=2.3.0"
 
 [[package]]
 name = "packaging"
-version = "21.3"
+version = "22.0"
 description = "Core utilities for Python packages"
 category = "main"
 optional = false
-python-versions = ">=3.6"
-
-[package.dependencies]
-pyparsing = ">=2.0.2,<3.0.5 || >3.0.5"
+python-versions = ">=3.7"
 
 [[package]]
 name = "pluggy"
@@ -322,17 +316,6 @@ docs = ["sphinx (>=4.5.0,<5.0.0)", "sphinx-rtd-theme", "zope.interface"]
 tests = ["pytest (>=6.0.0,<7.0.0)", "coverage[toml] (==5.0.4)"]
 
 [[package]]
-name = "pyparsing"
-version = "3.0.9"
-description = "pyparsing module - Classes and methods to define and execute parsing grammars"
-category = "main"
-optional = false
-python-versions = ">=3.6.8"
-
-[package.extras]
-diagrams = ["railroad-diagrams", "jinja2"]
-
-[[package]]
 name = "pytest"
 version = "7.2.0"
 description = "pytest: simple powerful testing with Python"
@@ -343,16 +326,18 @@ python-versions = ">=3.7"
 [package.dependencies]
 attrs = ">=19.2.0"
 colorama = {version = "*", markers = "sys_platform == \"win32\""}
+exceptiongroup = {version = ">=1.0.0rc8", markers = "python_version < \"3.11\""}
 iniconfig = "*"
 packaging = "*"
 pluggy = ">=0.12,<2.0"
+tomli = {version = ">=1.0.0", markers = "python_version < \"3.11\""}
 
 [package.extras]
 testing = ["argcomplete", "hypothesis (>=3.56)", "mock", "nose", "pygments (>=2.7.2)", "requests", "xmlschema"]
 
 [[package]]
 name = "pytest-asyncio"
-version = "0.20.1"
+version = "0.20.3"
 description = "Pytest support for asyncio"
 category = "main"
 optional = false
@@ -362,20 +347,19 @@ python-versions = ">=3.7"
 pytest = ">=6.1.0"
 
 [package.extras]
+docs = ["sphinx (>=5.3)", "sphinx-rtd-theme (>=1.0)"]
 testing = ["coverage (>=6.2)", "hypothesis (>=5.7.1)", "flaky (>=3.5.0)", "mypy (>=0.931)", "pytest-trio (>=0.7.0)"]
 
 [[package]]
 name = "redis"
-version = "4.3.4"
+version = "4.4.0"
 description = "Python client for Redis database and key-value store"
 category = "main"
 optional = false
-python-versions = ">=3.6"
+python-versions = ">=3.7"
 
 [package.dependencies]
 async-timeout = ">=4.0.2"
-deprecated = ">=1.2.3"
-packaging = ">=20.4"
 
 [package.extras]
 hiredis = ["hiredis (>=1.0.0)"]
@@ -437,7 +421,7 @@ full = ["itsdangerous", "jinja2", "python-multipart", "pyyaml", "requests"]
 
 [[package]]
 name = "starlette-context"
-version = "0.3.4"
+version = "0.3.5"
 description = "Access context in Starlette"
 category = "main"
 optional = false
@@ -445,6 +429,14 @@ python-versions = ">=3.7"
 
 [package.dependencies]
 starlette = "*"
+
+[[package]]
+name = "tomli"
+version = "2.0.1"
+description = "A lil' TOML parser"
+category = "main"
+optional = false
+python-versions = ">=3.7"
 
 [[package]]
 name = "tqdm"
@@ -490,11 +482,11 @@ python-versions = ">=3.7"
 
 [[package]]
 name = "urllib3"
-version = "1.26.12"
+version = "1.26.13"
 description = "HTTP library with thread-safe connection pooling, file post, and more."
 category = "main"
 optional = false
-python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, !=3.5.*, <4"
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, !=3.5.*"
 
 [package.extras]
 brotli = ["brotlicffi (>=0.8.0)", "brotli (>=1.0.9)", "brotlipy (>=0.6.0)"]
@@ -516,18 +508,10 @@ h11 = ">=0.8"
 [package.extras]
 standard = ["colorama (>=0.4)", "httptools (>=0.5.0)", "python-dotenv (>=0.13)", "pyyaml (>=5.1)", "uvloop (>=0.14.0,!=0.15.0,!=0.15.1)", "watchfiles (>=0.13)", "websockets (>=10.0)"]
 
-[[package]]
-name = "wrapt"
-version = "1.14.1"
-description = "Module for decorators, wrappers and monkey patching."
-category = "main"
-optional = false
-python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,>=2.7"
-
 [metadata]
 lock-version = "1.1"
-python-versions = "^3.11"
-content-hash = "f0358a12b1edef8483c877fc7328a8e0013a00ca10392357bbde2b9cdc1a495e"
+python-versions = "^3.10"
+content-hash = "0972711884d9448e146f3e8af1fe88f8d1b6c306d42c71f45d0a421540bd2105"
 
 [metadata.files]
 aiofiles = []
@@ -537,18 +521,12 @@ attrs = []
 camel-converter = []
 certifi = []
 charset-normalizer = []
-click = [
-    {file = "click-8.1.3-py3-none-any.whl", hash = "sha256:bb4d8133cb15a609f44e8213d9b391b0809795062913b383c62be0ee95b1db48"},
-    {file = "click-8.1.3.tar.gz", hash = "sha256:7682dc8afb30297001674575ea00d1814d808d6a36af415a82bd481d37ba7b8e"},
-]
+click = []
 colorama = []
-deprecated = []
+exceptiongroup = []
 fastapi = []
 gunicorn = []
-h11 = [
-    {file = "h11-0.12.0-py3-none-any.whl", hash = "sha256:36a3cb8c0a032f56e2da7084577878a035d3b61d104230d4bd49c0c6b555a9c6"},
-    {file = "h11-0.12.0.tar.gz", hash = "sha256:47222cb6067e4a307d535814917cd98fd0a57b6788ce715755fa2b6c28b56042"},
-]
+h11 = []
 h2 = []
 hpack = []
 httpcore = []
@@ -558,29 +536,22 @@ idna = []
 iniconfig = []
 meilisearch = []
 meilisearch-python-async = []
-packaging = [
-    {file = "packaging-21.3-py3-none-any.whl", hash = "sha256:ef103e05f519cdc783ae24ea4e2e0f508a9c99b2d4969652eed6a2e1ea5bd522"},
-    {file = "packaging-21.3.tar.gz", hash = "sha256:dd47c42927d89ab911e606518907cc2d3a1f38bbd026385970643f9c5b8ecfeb"},
-]
+packaging = []
 pluggy = []
 psycopg2-binary = []
 pydantic = []
 pyjwt = []
-pyparsing = []
 pytest = []
 pytest-asyncio = []
 redis = []
 requests = []
-rfc3986 = [
-    {file = "rfc3986-1.5.0-py2.py3-none-any.whl", hash = "sha256:a86d6e1f5b1dc238b218b012df0aa79409667bb209e58da56d0b94704e712a97"},
-    {file = "rfc3986-1.5.0.tar.gz", hash = "sha256:270aaf10d87d0d4e095063c65bf3ddbc6ee3d0b226328ce21e036f946e421835"},
-]
+rfc3986 = []
 sniffio = []
 starlette = []
 starlette-context = []
+tomli = []
 tqdm = []
 typer = []
 typing-extensions = []
 urllib3 = []
 uvicorn = []
-wrapt = []

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -15,7 +15,7 @@ fastapi = "^0.86.0"
 gunicorn = "^20.1.0"
 httpx = { version = "^0.23.0", extras = ["http2"] }
 pytest-asyncio = "^0.20.1"
-meilisearch-python-async = "^0.28.1"
+meilisearch-python-async = "^0.29.1"
 starlette-context = "^0.3.4"
 redis = "^4.3.4"
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -109,7 +109,7 @@ services:
       - "traefik.docker.network=traefik"
 
   search:
-    image: getmeili/meilisearch:v0.29.2
+    image: getmeili/meilisearch:v0.30.2
     restart: always
     container_name: search
     environment:


### PR DESCRIPTION
# Description

- Removes stale/dead media from Meilisearch

This should remove some of the adult things that TMDB remove too late, and stop the database from growing infinitely with junk media

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
