### PR TITLE
fix: theme selector not opening on mobile

### DIFF
--- a/frontend/src/lib/components/navbar/phone_navbar.svelte
+++ b/frontend/src/lib/components/navbar/phone_navbar.svelte
@@ -2,8 +2,8 @@
 <script lang="ts">
   import type { main_Country } from "$lib/generated/go"
 
-  import CountrySelector from "../country_selector.svelte"
-  import ThemeSelector from "../theme_selector.svelte"
+  import CountrySelector from "$lib/components/country_selector.svelte"
+  import ThemeSelector from "$lib/components/theme_selector.svelte"
 
   export let countries: main_Country[]
 

--- a/frontend/src/lib/components/theme_selector.svelte
+++ b/frontend/src/lib/components/theme_selector.svelte
@@ -2,7 +2,7 @@
   import { themeChange } from "theme-change"
   import { onMount } from "svelte"
   import { chosenTheme } from "$lib/stores/preferences"
-  import { THEMES } from "../variables.js"
+  import { THEMES } from "$lib/variables.js"
 
   let isDropdownOpen = false
 
@@ -22,10 +22,11 @@
 </script>
 
 <div class="dropdown dropdown-end" on:focusout={handleDropdownFocusLost}>
-  <button
-    tabindex="0"
+  <div
+    tabindex="-1"
     class="btn btn-ghost btn-sm rounded-btn text-xl"
     on:click={handleDropdownClick}
+    on:keypress={handleDropdownClick}
   >
     {#if isDropdownOpen}
       <svg
@@ -50,7 +51,7 @@
         /></svg
       >
     {/if}
-  </button>
+  </div>
   <ul
     tabindex="-1"
     class="p-2 shadow menu dropdown-content bg-base-100 rounded-box w-52"


### PR DESCRIPTION
# Description

Fixes theme selector that is unusable on mobile

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
