### PR TITLE
Add people to meilisearch media, and therefore searchable

### DIFF
--- a/backend/app/api.py
+++ b/backend/app/api.py
@@ -124,32 +124,6 @@ def fetch_media_ids(
     return movie_ids, tv_ids, person_ids
 
 
-def fetch_changed_media_ids() -> Tuple[list[str], list[str]]:
-    tmdb_url = get_settings().tmdb_url
-    tmdb_key = get_settings().tmdb_key
-    today = datetime.today().strftime("%Y-%m-%d")
-    yesterday = (datetime.today() - timedelta(days=1)).strftime("%Y-%m-%d")
-
-    with httpx.Client(http2=True) as client:
-        movie_res = client.get(
-            f"{tmdb_url}movie/changes?api_key={tmdb_key}&"
-            f"end_date={today}&start_date={yesterday}&page=1"
-        )
-        tv_res = client.get(
-            f"{tmdb_url}tv/changes?api_key={tmdb_key}&"
-            f"end_date={today}&start_date={yesterday}&page=1"
-        )
-
-    movie_ids = [
-        f"m{movie['id']}"
-        for movie in movie_res.json()["results"]
-        if not movie.get("adult")
-    ]
-    tv_ids = [f"t{tv['id']}" for tv in tv_res.json()["results"] if not tv.get("adult")]
-
-    return movie_ids, tv_ids
-
-
 def fetch_trending_movies(page: int) -> dict:
     url = f"{tmdb_url}trending/movie/week?api_key={tmdb_key}&page={page}"
     return requests.get(url).json()["results"]

--- a/backend/app/db/database_service.py
+++ b/backend/app/db/database_service.py
@@ -60,13 +60,13 @@ async def fetch_countries_with_providers() -> list[dict[str, str]]:
 
     try:
         documents = await async_client.index("media").get_documents(
-            limit=1_000_000, fields=["supported_provider_countries"]
+            limit=1_000_000, fields=["supported_provider_countries", "id"]
         )
-
         # Gather and flatten supported country providers into set
         supported_countries = {
             country
             for document in documents.results
+            if not document["id"][0] == "p"
             for country in document["supported_provider_countries"]
         }
 

--- a/backend/cli.py
+++ b/backend/cli.py
@@ -11,7 +11,6 @@ from pathlib import Path
 import httpx
 import requests
 import typer
-from app.api import fetch_changed_media_ids
 from app.api import fetch_genres
 from app.api import fetch_jsongz_files
 from app.api import fetch_media_ids
@@ -33,8 +32,6 @@ from app.util import chunkify
 from app.util import coroutine
 from meilisearch.errors import MeiliSearchApiError
 from tqdm import tqdm
-
-# from app.api import fetch_changed_media_ids
 
 supported_country_codes = get_settings().supported_country_codes
 
@@ -212,7 +209,7 @@ def update_ids(ids: list[str]):
 
 
 @app.command()
-def update_media(chunk_size: int = 25000, popularity: float = 1):
+def update_media(chunk_size: int, popularity: float = 1):
     """Sends media ids to our internal update-media endpoint in chunks"""
     movie_ids, tv_ids, person_ids = fetch_media_ids(popularity)
 
@@ -285,9 +282,7 @@ async def clean_stale_media():
 
 @app.command()
 @coroutine
-async def full_setup(
-    popularity: float = 1, chunk_size: int = 25000
-):
+async def full_setup(popularity: float = 1, chunk_size: int = 25000):
     await insert_genres_to_cache(fetch_genres())
     await insert_genres(db_client, data=json.dumps(fix_genre_ampersand(fetch_genres())))
     await providers_to_redis()

--- a/backend/cli.py
+++ b/backend/cli.py
@@ -218,8 +218,8 @@ def update_media(chunk_size: int = 25000, popularity: float = 1):
 
     print(
         f"\nAbout to update {len(movie_ids)} movies, {len(tv_ids)} "
-        "TV shows and {len(person_ids)} people"
-        f" in chunks of {chunk_size}"
+        f"TV shows and {len(person_ids)} people "
+        f"in chunks of {chunk_size}"
     )
 
     with httpx.Client(http2=True, timeout=60) as client:

--- a/frontend/src/lib/components/filters.svelte
+++ b/frontend/src/lib/components/filters.svelte
@@ -12,7 +12,8 @@
 
   $: sortingAmount = Object.values($sorting.by).filter(v => v === true).length
   $: imdbAmount = $filters.minImdb != 0 ? 1 : 0
-  $: filterAmount = Object.values($filters).filter(v => v === false).length + imdbAmount
+  $: filterAmount =
+    Object.values($filters.checked).filter(v => v === true).length + imdbAmount
   $: totalAmount =
     sortingAmount + filterAmount + (sortingAmount ? ($sorting.asc ? 1 : 0) : 0)
 
@@ -118,11 +119,9 @@
               <input
                 type="checkbox"
                 class="toggle"
-                bind:checked={$filters.movieChecked}
+                bind:checked={$filters.checked.movie}
                 on:change={() => {
-                  if (!$filters.movieChecked) {
-                    $filters.tvChecked = true
-                  }
+                  $filters.checked.person = false
                   search()
                 }}
               />
@@ -132,10 +131,24 @@
               <input
                 type="checkbox"
                 class="toggle"
-                bind:checked={$filters.tvChecked}
+                bind:checked={$filters.checked.tv}
                 on:change={() => {
-                  if (!$filters.tvChecked) {
-                    $filters.movieChecked = true
+                  $filters.checked.person = false
+                  search()
+                }}
+              />
+            </label>
+            <label class="label cursor-pointer">
+              <span class="label-text">People</span>
+              <input
+                type="checkbox"
+                class="toggle"
+                bind:checked={$filters.checked.person}
+                on:change={() => {
+                  if ($filters.checked.person) {
+                    $filters.checked.tv = false
+                    $filters.checked.movie = false
+                    $filters.minImdb = 0
                   }
                   search()
                 }}
@@ -151,7 +164,10 @@
             min="0.0"
             max="10.0"
             step="0.1"
-            on:change={search}
+            on:change={() => {
+              $filters.checked.person = false
+              search()
+            }}
             bind:value={$filters.minImdb}
             class="range"
           />
@@ -160,8 +176,9 @@
             class="btn btn-xs {filterAmount ? 'btn-primary' : 'btn-disabled'}"
             on:click={() => {
               $filters.minImdb = 0
-              $filters.tvChecked = true
-              $filters.movieChecked = true
+              for (const key in $filters.checked) {
+                $filters.checked[key] = false
+              }
               search()
             }}>{filterAmount ? "Clear filters" : "No filters chosen"}</button
           >

--- a/frontend/src/lib/components/media_card.svelte
+++ b/frontend/src/lib/components/media_card.svelte
@@ -72,9 +72,15 @@
   {/if}
   {#if providerAmounts[mediaIndex] === 0}
     <div class="card-body h-14">
-      <p class="text-center text-neutral-content">
-        <strong>No providers in {$currentCountry}</strong>
-      </p>
+      {#if media.id.charAt(0) == "p"}
+        <p class="text-center text-neutral-content">
+          <strong>{media.title}</strong>
+        </p>
+      {:else}
+        <p class="text-center text-neutral-content">
+          <strong>No providers in {$currentCountry}</strong>
+        </p>
+      {/if}
     </div>
   {:else if providerAmounts[mediaIndex] <= SHOWN_PROVIDERS}
     <div class="-space-x-4 avatar-group">

--- a/frontend/src/lib/components/no_results.svelte
+++ b/frontend/src/lib/components/no_results.svelte
@@ -28,12 +28,15 @@
         <i>Consider adding more providers or removing all</i>
       </p>
     {/if}
-    {#if Object.values($filters).includes(false) || $filters.minImdb}
+    {#if Object.values($filters.checked).includes(true) || $filters.minImdb}
       <p class="pt-2">With filter(s):</p>
-      {#if !$filters.movieChecked}
+      {#if !$filters.checked.person}
+        <div class="badge mx-1">No people</div>
+      {/if}
+      {#if !$filters.checked.movie}
         <div class="badge mx-1">No movies</div>
       {/if}
-      {#if !$filters.tvChecked}
+      {#if !$filters.checked.tv}
         <div class="badge mx-1">No TV shows</div>
       {/if}
       {#if $filters.minImdb}

--- a/frontend/src/lib/stores/preferences.ts
+++ b/frontend/src/lib/stores/preferences.ts
@@ -44,13 +44,14 @@ export const sorting = writable<Sorting>(
 interface Filters {
   tvChecked: boolean
   movieChecked: boolean
+  personChecked: boolean
   minImdb: number
 }
 
 export const filters = writable<Filters>(
   browser && sessionStorage.getItem("filters") !== null
     ? JSON.parse(sessionStorage.getItem("filters"))
-    : { tvChecked: true, movieChecked: true, minImdb: 0 }
+    : { checked: { tv: false, movie: false, person: false }, minImdb: 0 }
 )
 
 filters.subscribe(value => {
@@ -65,8 +66,8 @@ export const chosenTheme = writable<string>(
 
 export const currentCountry = writable<string>(
   (browser && localStorage.currentCountry) ||
-    (browser && sessionStorage.currentCountry) ||
-    "DK"
+  (browser && sessionStorage.currentCountry) ||
+  "DK"
 )
 
 currentCountry.subscribe(value => {

--- a/frontend/src/lib/stores/preferences.ts
+++ b/frontend/src/lib/stores/preferences.ts
@@ -42,9 +42,11 @@ export const sorting = writable<Sorting>(
 )
 
 interface Filters {
-  tvChecked: boolean
-  movieChecked: boolean
-  personChecked: boolean
+  checked: {
+    tv: boolean
+    movie: boolean
+    person: boolean
+  }
   minImdb: number
 }
 
@@ -66,8 +68,8 @@ export const chosenTheme = writable<string>(
 
 export const currentCountry = writable<string>(
   (browser && localStorage.currentCountry) ||
-  (browser && sessionStorage.currentCountry) ||
-  "DK"
+    (browser && sessionStorage.currentCountry) ||
+    "DK"
 )
 
 currentCountry.subscribe(value => {

--- a/frontend/src/routes/+page.svelte
+++ b/frontend/src/routes/+page.svelte
@@ -45,14 +45,24 @@
   }
 
   const search = async () => {
-    // Builds the optional query for genres
-    // Example: "?g=Action&g=Comedy&g=Drama"
-
     if (!currentMediaAmount) {
       setViewportToDefault()
     }
 
+    // Builds the optional query for genres
+    // Example: "?g=Action&g=Comedy&g=Drama"
     let query = ""
+    let userInput = input.replace(/[^\w\d\s\&]/g, " ")
+
+    // Searches for all(*) if empty input
+    // Empty input will only return media with providers
+    if (input == "") {
+      userInput = "*" 
+      if (!$filters.checked.person) {
+        query += "&only_providers=true"
+      }
+    } 
+    
     for (let i = 0; i < $currentGenres.length; i++) {
       query += `&g=${$currentGenres[i].value}`
     }
@@ -60,11 +70,14 @@
       query += `&p=${$currentProviders[i].value}`
     }
 
-    if ($filters.tvChecked && $filters.movieChecked) {
-    } else if ($filters.movieChecked) {
+    if ($filters.checked.movie) {
       query += "&t=movie"
-    } else {
+    }
+    if ($filters.checked.tv) {
       query += "&t=tv"
+    } 
+    if ($filters.checked.person) {
+      query += "&t=person"
     }
 
     if ($filters.minImdb) {
@@ -78,27 +91,16 @@
     } else if ($sorting.by.imdbRating) {
       query += `&imdb_rating=${$sorting.asc ? "asc" : "desc"}`
     }
-    // Searches for all(*) if empty input
-    // Empty input will only return media with providers
-    const res =
-      input !== ""
-        ? await fetch(
-            SEARCH_URL +
-              input.replace(/[^\w\d\s\&]/g, " ") +
-              "?c=" +
-              $currentCountry +
-              query +
-              `&limit=${currentMediaAmount}`
-          )
-        : await fetch(
-            SEARCH_URL +
-              "*" +
-              "?c=" +
-              $currentCountry +
-              query +
-              `&limit=${currentMediaAmount}` +
-              "&only_providers=true"
-          )
+
+    const res = await fetch(
+      SEARCH_URL +
+        userInput +
+        "?c=" +
+        $currentCountry +
+        query +
+        `&limit=${currentMediaAmount}` 
+    )
+
     $inputQuery = input
     meilisearch = await res.json()
     providerAmounts = hitProviderAmounts(meilisearch.hits, $currentCountry)

--- a/frontend/src/routes/+page.svelte
+++ b/frontend/src/routes/+page.svelte
@@ -52,6 +52,9 @@
     // Builds the optional query for genres
     // Example: "?g=Action&g=Comedy&g=Drama"
     let query = ""
+
+    // Sanitizes input by removing any character that is not a letter,
+    // number, whitespace or an ampersand and replaces them with a space
     let userInput = input.replace(/[^\w\d\s\&]/g, " ")
 
     // Searches for all(*) if empty input

--- a/frontend/src/routes/+page.svelte
+++ b/frontend/src/routes/+page.svelte
@@ -57,12 +57,12 @@
     // Searches for all(*) if empty input
     // Empty input will only return media with providers
     if (input == "") {
-      userInput = "*" 
+      userInput = "*"
       if (!$filters.checked.person) {
         query += "&only_providers=true"
       }
-    } 
-    
+    }
+
     for (let i = 0; i < $currentGenres.length; i++) {
       query += `&g=${$currentGenres[i].value}`
     }
@@ -75,7 +75,7 @@
     }
     if ($filters.checked.tv) {
       query += "&t=tv"
-    } 
+    }
     if ($filters.checked.person) {
       query += "&t=person"
     }
@@ -98,7 +98,7 @@
         "?c=" +
         $currentCountry +
         query +
-        `&limit=${currentMediaAmount}` 
+        `&limit=${currentMediaAmount}`
     )
 
     $inputQuery = input

--- a/internal/main.go
+++ b/internal/main.go
@@ -23,6 +23,6 @@ func main() {
 
 	router.GET("/", DocsRedirect)
 	router.GET("/docs/*any", ginSwagger.WrapHandler(swaggerFiles.Handler))
-	router.POST("/update-media", processIds)
+	router.POST("/update-media", processMedia)
 	router.Run(":8888")
 }

--- a/internal/types.go
+++ b/internal/types.go
@@ -78,7 +78,7 @@ type Person struct {
 	KnownForDepartment string  `json:"known_for_department"`
 	PlaceOfBirth       string  `json:"place_of_birth"`
 	Biography          string  `json:"biography"`
-  // TODO: Add rest of person items when we migrate to edgeDB
+	// TODO: Add rest of person items when we migrate to edgeDB
 }
 
 func (person *Person) toMedia() *Media {

--- a/internal/types.go
+++ b/internal/types.go
@@ -78,10 +78,7 @@ type Person struct {
 	KnownForDepartment string  `json:"known_for_department"`
 	PlaceOfBirth       string  `json:"place_of_birth"`
 	Biography          string  `json:"biography"`
-	// MovieCredits []struct {
-	//   Cast [] struct {
-	//   } `json:"cast"`
-	// } `json:"movie_credits"`
+  // TODO: Add rest of person items when we migrate to edgeDB
 }
 
 func (person *Person) toMedia() *Media {

--- a/internal/types.go
+++ b/internal/types.go
@@ -67,6 +67,38 @@ func (movie *Movie) toMedia() *Media {
 	}
 }
 
+type Person struct {
+	Id                 int     `json:"id"`
+	Name               string  `json:"name"`
+	Gender             int     `json:"gender"`
+	ImdbId             string  `json:"imdb_id"`
+	ProfilePath        string  `json:"profile_path"`
+	Popularity         float32 `json:"popularity"`
+	Birthday           string  `json:"birthday"`
+	KnownForDepartment string  `json:"known_for_department"`
+	PlaceOfBirth       string  `json:"place_of_birth"`
+	Biography          string  `json:"biography"`
+	// MovieCredits []struct {
+	//   Cast [] struct {
+	//   } `json:"cast"`
+	// } `json:"movie_credits"`
+}
+
+func (person *Person) toMedia() *Media {
+	personId := "p" + strconv.Itoa(person.Id)
+	return &Media{
+		Id:            personId,
+		ImdbId:        person.ImdbId,
+		Type:          getMediaType(personId),
+		Title:         person.Name,
+		Overview:      person.Biography,
+		PosterPath:    person.ProfilePath,
+		Popularity:    person.Popularity,
+		UpdatedAt:     time.Now(),
+		UpdatedAtUnix: time.Now().Unix(),
+	}
+}
+
 type TV struct {
 	Id           int         `json:"id"`
 	ExternalIds  ExternalIds `json:"external_ids"`
@@ -163,6 +195,8 @@ func getMediaType(id string) string {
 		return "movie"
 	case "t":
 		return "tv"
+	case "p":
+		return "person"
 	default:
 		panic(fmt.Sprintf("Received unexpected media type, got: %s", id))
 	}

--- a/justfile
+++ b/justfile
@@ -1,7 +1,7 @@
 # I've gathered some of the most used commands in Streamchaser for ease of use
 
-full-setup popularity:
-  docker-compose exec backend python3 cli.py full-setup --popularity {{popularity}}
+full-setup popularity chunk_size="25000":
+  docker-compose exec backend python3 cli.py full-setup --chunk-size {{chunk_size}} --popularity {{popularity}}
 
 migrate:
   edgedb --tls-security=insecure -P 5656 --user edgedb --password migrate

--- a/justfile
+++ b/justfile
@@ -1,7 +1,7 @@
 # I've gathered some of the most used commands in Streamchaser for ease of use
 
 full-setup popularity:
-  docker-compose exec backend python3 cli.py full-setup --first-time --popularity {{popularity}}
+  docker-compose exec backend python3 cli.py full-setup --popularity {{popularity}}
 
 migrate:
   edgedb --tls-security=insecure -P 5656 --user edgedb --password migrate


### PR DESCRIPTION
# Description

This adds people to be searchable. This PR comes with some decisions that i am unsure if we want to continue with. For an example it adds people to the `media` index of meilisearch, but i am unsure if we want a separate one. I liked the idea of having one "master" index though.

Furthermore this adds quite a lot of API alls to `tmdb`, and makes the running through `json.gz` files take quite a lot longer since the new person file is quite long.

This also removes the `first-time` parameter of our `full-setup` since it was never used anyway. It is not triggered from providers being updated, and thus useless for us.

![image](https://user-images.githubusercontent.com/50198099/222992680-feeb4817-7fe9-4e52-9407-d84109017058.png)


## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
