### PR TITLE
chore: remove --platform Python hack

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,7 +2,7 @@ ci:
   autoupdate_schedule: monthly # weekly(default), monthly, quarterly
 
 default_language_version:
-  python: python3.10
+  python: python3.11
 
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,7 +1,7 @@
 ARG APP_ENVIRONMENT=dev
 
 
-FROM --platform=linux/amd64 python:3.11-slim as base
+FROM python:3.11 as base
 
 WORKDIR /app
 


### PR DESCRIPTION
# Description

- Removes the hack - Should be a performance boost for M1/M2 architectures

Background: We used to have an issue on M1 Macs when installing our Python dependencies because of psycopg. That is no longer an issue

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
