### PR TITLE
feat: add QoL access to cli.py with 'just cli <command>'

### DIFF
--- a/justfile
+++ b/justfile
@@ -14,3 +14,6 @@ db-ui:
 
 generate-edgedb-python:
   cd backend/ && poetry run edgedb-py -P 5656 --tls-security insecure --user edgedb --password secret && cd ../
+
+cli command="--help":
+  docker-compose exec backend python3 cli.py {{command}}


### PR DESCRIPTION
# Description

`just cli <command>`
instead of
`docker-compose exec backend python3 cli.py <command>`

And defaults to --help when no command

<img src="https://media4.giphy.com/media/n3p6JiIG0TzCU/giphy-downsized-medium.gif"/>