### PR TITLE
chore: remove svelte-preprocess (we use vite's now)

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -21,7 +21,6 @@
     "postcss": "^8.4.5",
     "svelte": "^3.57.0",
     "svelte-check": "^2.10.2",
-    "svelte-preprocess": "^4.9.8",
     "tailwindcss": "^3.0.17",
     "typescript": "^4.4.4",
     "vite": "^4.2.1"

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -1920,7 +1920,7 @@ svelte-media-query@^1.1.1:
   resolved "https://registry.yarnpkg.com/svelte-media-query/-/svelte-media-query-1.1.2.tgz#640bd764c670f0547634bd3b2ea5cbd6d5f8c195"
   integrity sha512-wprqLjnTDhHsoCwCobMp06laiBb9sz8FeKQixEm9teS0tbPb2nmlzy3vlbDX5MPwNRyNML1/1SHmshQQnQ77+w==
 
-svelte-preprocess@^4.0.0, svelte-preprocess@^4.9.8:
+svelte-preprocess@^4.0.0:
   version "4.10.7"
   resolved "https://registry.yarnpkg.com/svelte-preprocess/-/svelte-preprocess-4.10.7.tgz#3626de472f51ffe20c9bc71eff5a3da66797c362"
   integrity sha512-sNPBnqYD6FnmdBrUmBCaqS00RyCsCpj2BG58A1JBswNF7b0OKviwxqVrOL/CKyJrLSClrSeqQv5BXNg2RUbPOw==


### PR DESCRIPTION
# Description

We are using Vite's 🦄  shiny preprocessor ✨ 
