### PR TITLE
Up cookie disclaimer delay

### DIFF
--- a/frontend/src/lib/components/cookie_disclaimer.svelte
+++ b/frontend/src/lib/components/cookie_disclaimer.svelte
@@ -38,7 +38,7 @@
   }
 
   onMount(async () => {
-    setTimeout(() => (loadDisclaimer = true), 100)
+    setTimeout(() => (loadDisclaimer = true), 500)
   })
 </script>
 

--- a/frontend/src/lib/components/details/top_card.svelte
+++ b/frontend/src/lib/components/details/top_card.svelte
@@ -53,7 +53,7 @@
                 text-neutral-content shadow-md"
   >
     {#if posterPath}
-      <figure class="pt-10 pr-10 pl-10 sm:p-6">
+      <figure class="pt-10 pr-10 pl-10 sm:p-6 aspect-[342/513]">
         <img
           src="{IMG_W500}{posterPath}"
           class="object-contain sm:max-h-96 w-full rounded-box"
@@ -61,7 +61,7 @@
         />
       </figure>
     {:else}
-      <figure class="pt-10 pr-10 pl-10 sm:p-6">
+      <figure class="pt-10 pr-10 pl-10 sm:p-6 aspect-[342/513]">
         <div
           class="h-96 bg-slate-100 object-contain sm:max-h-96 rounded-box
                 grid place-items-center"


### PR DESCRIPTION
# Description

This makes Cookie disclaimer not sometimes pop up when changing page for a short second even when the cookie has been accepted.

Also adds a aspect ratio to top_card to minimize jumping of the image
