### PR TITLE
fix: edgedb doesnt work with the new version 3. Pinned version to 2.7

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -110,7 +110,7 @@ services:
 
   edgedb:
     container_name: edgedb
-    image: edgedb/edgedb
+    image: edgedb/edgedb:2.7
     environment:
       EDGEDB_SERVER_TLS_CERT_MODE: generate_self_signed
       EDGEDB_SERVER_ADMIN_UI: enabled


### PR DESCRIPTION
# Description

We currently just pull the latest edgedb image, but it breaks our setup currently since they went to version 3.0. This pins the version to 2.7, which works.