### PR TITLE
feat: update svelte-select and add search in navbar for large desktops

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -34,7 +34,7 @@
     "playwright": "^1.33.0",
     "svelte-infinite-loading": "^1.3.8",
     "svelte-media-query": "^1.1.1",
-    "svelte-select": "https://github.com/AndreasPB/svelte-select",
+    "svelte-select": "^5.6.1",
     "theme-change": "^2.0.2"
   }
 }

--- a/frontend/src/lib/components/country_selector.svelte
+++ b/frontend/src/lib/components/country_selector.svelte
@@ -2,6 +2,7 @@
   import { currentCountry } from "$lib/stores/preferences"
   import { isBurgerMenuOpen } from "$lib/stores/stores"
   import type { SelectCountriesResult } from "$lib/generated"
+  import SvelteSelectCSS from "$lib/components/svelte_select_css.svelte"
   import Select from "svelte-select"
   import { get } from "svelte/store"
 
@@ -9,26 +10,7 @@
 </script>
 
 <div>
-  <div
-    class="sm:w-32 md:w-52 lg:w-56 w-52"
-    style="
-   --borderRadius: var(--rounded-btn, .5rem);
-   --background: hsl(var(--b1));
-   --border: 1px solid hsl(var(--p));
-   --borderFocusColor: hsl(var(--p));
-   --borderHoverColor: hsl(var(--pf));
-   --itemColor: hsl(var(--er));
-   --itemIsActiveBG: hsl(var(--pf));
-   --itemIsActiveColor: hsl(var(--pc));
-   --clearSelectHoverColor: hsl(var(--pf));
-   --itemColor: hsl(var(--nc));
-   --listBackground: hsl(var(--n));
-   --itemHoverBG: hsl(var(--p));
-   --itemHoverColor: hsl(var(--pc));
-   --inputColor: hsl(var(--bc));
-   --clearSelectFocusColor: hsl(var(--p));
-  "
-  >
+  <SvelteSelectCSS tailwind="sm:w-32 md:w-52 lg:w-56 w-52">
     <Select
       value={countries[countries.findIndex(v => v.value === get(currentCountry))]}
       on:select={e => {
@@ -37,7 +19,7 @@
       }}
       items={countries}
       placeholder="Select country..."
-      isClearable={false}
+      clearable={false}
     />
-  </div>
+  </SvelteSelectCSS>
 </div>

--- a/frontend/src/lib/components/navbar/navbar.svelte
+++ b/frontend/src/lib/components/navbar/navbar.svelte
@@ -5,6 +5,7 @@
   import Auth from "$lib/components/sign_in/auth.svelte"
   import ThemeSelector from "$lib/components/theme_selector.svelte"
   import { env } from "$env/dynamic/public"
+  import { page } from "$app/stores"
   import SearchDropdown from "../search_dropdown.svelte"
   import MediaQuery from "svelte-media-query"
 
@@ -22,7 +23,7 @@
     </a>
   </div>
   <MediaQuery query="(min-width: 1100px)" let:matches>
-    {#if matches}
+    {#if matches && $page.url.pathname != "/"}
       <SearchDropdown />
     {/if}
   </MediaQuery>

--- a/frontend/src/lib/components/navbar/navbar.svelte
+++ b/frontend/src/lib/components/navbar/navbar.svelte
@@ -5,6 +5,8 @@
   import Auth from "$lib/components/sign_in/auth.svelte"
   import ThemeSelector from "$lib/components/theme_selector.svelte"
   import { env } from "$env/dynamic/public"
+  import SearchDropdown from "../search_dropdown.svelte"
+  import MediaQuery from "svelte-media-query"
 
   export let countries: SelectCountriesResult[]
 </script>
@@ -19,7 +21,12 @@
       />
     </a>
   </div>
-  <div class="flex-1 px-2 mx-2" />
+  <MediaQuery query="(min-width: 1100px)" let:matches>
+    {#if matches}
+      <SearchDropdown />
+    {/if}
+  </MediaQuery>
+  <div class="flex-1 pr-2 mx-2" />
   <div class="flex-none">
     <div class="items-stretch hidden sm:flex">
       <a

--- a/frontend/src/lib/components/search_dropdown.svelte
+++ b/frontend/src/lib/components/search_dropdown.svelte
@@ -24,7 +24,7 @@
   <SvelteSelectCss tailwind="w-96">
     <Select
       loadOptions={search}
-      placeholder="Seach..."
+      placeholder="Search..."
       clearable={false}
       on:input={e => {
         window.location.href = mediaIdToUrlConverter(e.detail.id)

--- a/frontend/src/lib/components/search_dropdown.svelte
+++ b/frontend/src/lib/components/search_dropdown.svelte
@@ -1,0 +1,45 @@
+<script lang="ts">
+  import type { Meilisearch } from "$lib/generated"
+  import { PYTHON_API } from "$lib/variables"
+  import Select from "svelte-select"
+  import { mediaIdToUrlConverter } from "$lib/utils"
+  import SvelteSelectCss from "./svelte_select_css.svelte"
+
+  let meilisearch: Meilisearch
+
+  const SEARCH_URL = `${PYTHON_API}/search/`
+
+  const search = async (filterText: string) => {
+    if (!filterText.length) {
+      return Promise.resolve([])
+    }
+
+    const res = await fetch(SEARCH_URL + filterText + "?limit=10")
+    meilisearch = await res.json()
+    return meilisearch.hits
+  }
+</script>
+
+<div>
+  <SvelteSelectCss tailwind="w-96">
+    <Select loadOptions={search} placeholder="Seach..." clearable={false}>
+      <a slot="item" let:item href={mediaIdToUrlConverter(item.id)}>
+        <div class="customItem">
+          <div class="customItem_title">
+            <div class="">{item.title}</div>
+            <!-- <div class="customItem_tagline">{item.}</div> -->
+          </div>
+        </div>
+      </a>
+
+      <div slot="selection" let:selection>
+        <div class="customItem">
+          <div class="customItem_title">
+            <div class="text-sm">{selection.title}</div>
+            <!-- <div class="customItem_tagline">{item.}</div> -->
+          </div>
+        </div>
+      </div>
+    </Select>
+  </SvelteSelectCss>
+</div>

--- a/frontend/src/lib/components/search_dropdown.svelte
+++ b/frontend/src/lib/components/search_dropdown.svelte
@@ -22,12 +22,45 @@
 
 <div>
   <SvelteSelectCss tailwind="w-96">
-    <Select loadOptions={search} placeholder="Seach..." clearable={false}>
+    <Select
+      loadOptions={search}
+      placeholder="Seach..."
+      clearable={false}
+      on:input={e => {
+        window.location.href = mediaIdToUrlConverter(e.detail.id)
+      }}
+    >
       <a slot="item" let:item href={mediaIdToUrlConverter(item.id)}>
-        <div class="customItem">
-          <div class="customItem_title">
-            <div class="">{item.title}</div>
-            <!-- <div class="customItem_tagline">{item.}</div> -->
+        <div class="flex flex-1 items-center truncate">
+          <div class="badge badge-secondary justify-center mr-2 w-8">
+            {#if item.id.startsWith("p")}
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                fill="currentColor"
+                height="1em"
+                width="1em"
+                viewBox="0 0 448 512"
+                ><!--! Font Awesome Free 6.4.0 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license (Commercial License) Copyright 2023 Fonticons, Inc. --><path
+                  d="M224 256A128 128 0 1 0 224 0a128 128 0 1 0 0 256zm-45.7 48C79.8 304 0 383.8 0 482.3C0 498.7 13.3 512 29.7 512H418.3c16.4 0 29.7-13.3 29.7-29.7C448 383.8 368.2 304 269.7 304H178.3z"
+                /></svg
+              >
+            {:else if item.id.startsWith("m")}
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                fill="currentColor"
+                height="1em"
+                width="1em"
+                viewBox="0 0 576 512"
+                ><!--! Font Awesome Free 6.4.0 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license (Commercial License) Copyright 2023 Fonticons, Inc. --><path
+                  d="M0 128C0 92.7 28.7 64 64 64H320c35.3 0 64 28.7 64 64V384c0 35.3-28.7 64-64 64H64c-35.3 0-64-28.7-64-64V128zM559.1 99.8c10.4 5.6 16.9 16.4 16.9 28.2V384c0 11.8-6.5 22.6-16.9 28.2s-23 5-32.9-1.6l-96-64L416 337.1V320 192 174.9l14.2-9.5 96-64c9.8-6.5 22.4-7.2 32.9-1.6z"
+                /></svg
+              >
+            {:else}
+              <p class="text-sm">TV</p>
+            {/if}
+          </div>
+          <div class="truncate">
+            <p class="truncate">{item.title}</p>
           </div>
         </div>
       </a>
@@ -36,7 +69,6 @@
         <div class="customItem">
           <div class="customItem_title">
             <div class="text-sm">{selection.title}</div>
-            <!-- <div class="customItem_tagline">{item.}</div> -->
           </div>
         </div>
       </div>

--- a/frontend/src/lib/components/svelte_select_css.svelte
+++ b/frontend/src/lib/components/svelte_select_css.svelte
@@ -1,0 +1,33 @@
+<script lang="ts">
+  export let tailwind: string
+</script>
+
+<div
+  class={tailwind}
+  style="
+       --border-radius: var(--rounded-btn, .5rem);
+       --background: hsl(var(--b1));
+       --spinner-color: hsl(var(--p));
+       --border: 1px solid hsl(var(--p));
+       --border-focused: 1px solid hsl(var(--p));
+       --border-hover: 1px solid hsl(var(--p));
+       --multi-item-outline: 1px solid hsl(var(--p));
+       --multi-item-border-radius: var(--rounded-btn, .5rem);
+       --multi-item-bg: hsl(var(--p));
+       --multi-item-color: hsl(var(--pc));
+       --multi-item-active-bg: hsl(var(--pf));
+       --multi-item-active-color: hsl(var(--bc));
+       --multi-item-clear-icon-color: hsl(var(--pc));
+       --clear-select-hover-color: hsl(var(--pf));
+       --itemIsActiveBG: hsl(var(--pc));
+       --item-color: hsl(var(--nc));
+       --list-background: hsl(var(--n));
+       --item-hover-bg: hsl(var(--p));
+       --item-hover-color: hsl(var(--pc));
+       --input-color: hsl(var(--bc));
+       --clear-select-focus-color: hsl(var(--p));
+       --placeholder-opacity: 100%;
+        "
+>
+  <slot />
+</div>

--- a/frontend/src/routes/+page.svelte
+++ b/frontend/src/routes/+page.svelte
@@ -4,6 +4,7 @@
   import Select from "svelte-select"
   import MediaSearch from "$lib/components/media_search.svelte"
   import Filters from "$lib/components/filters.svelte"
+  import SvelteSelectCSS from "$lib/components/svelte_select_css.svelte"
   import Head from "$lib/components/head.svelte"
   import {
     currentCountry,
@@ -163,65 +164,44 @@
     />
     <Filters {search} />
   </div>
-  <div
-    class="sm:grid sm:grid-cols-2 sm:gap-2 mt-2 mb-3"
-    style="
-             --borderRadius: var(--rounded-btn, .5rem);
-             --background: hsl(var(--b1));
-             --border: 1px solid hsl(var(--p));
-             --borderFocusColor: hsl(var(--p));
-             --borderHoverColor: hsl(var(--pf));
-             --multiItemBG: hsl(var(--p));
-             --multiItemColor: hsl(var(--pc));
-             --multiItemActiveBG: hsl(var(--pf));
-             --multiItemActiveColor: hsl(var(--bc));
-             --clearSelectHoverColor: hsl(var(--pf));
-             --itemIsActiveBG: hsl(var(--pc));
-             --itemColor: hsl(var(--nc));
-             --listBackground: hsl(var(--n));
-             --itemHoverBG: hsl(var(--p));
-             --itemHoverColor: hsl(var(--pc));
-             --inputColor: hsl(var(--bc));
-             --clearSelectFocusColor: hsl(var(--p));
-              "
-  >
+  <SvelteSelectCSS tailwind="sm:grid sm:grid-cols-2 sm:gap-2 mt-2 mb-3">
     <div class="mb-2 sm:mb-0">
       <Select
-        on:select={e => {
+        on:input={e => {
           $currentGenres = e.detail ? e.detail : []
           setViewportToDefault()
           search()
         }}
-        on:clear={e => {
-          $currentGenres = e.detail
-            ? $currentGenres.splice($currentGenres.indexOf(e.detail.value))
-            : []
+        on:clear={() => {
+          $currentGenres = []
+          setViewportToDefault()
+          search()
         }}
-        value={$currentGenres.length ? $currentGenres : null}
         items={data.genres}
-        isMulti={true}
+        multiple={true}
+        value={$currentGenres}
         placeholder="Select genres..."
       />
     </div>
     <div>
       <Select
-        on:select={e => {
+        on:input={e => {
           $currentProviders = e.detail ? e.detail : []
           setViewportToDefault()
           search()
         }}
-        on:clear={e => {
-          $currentProviders = e.detail
-            ? $currentProviders.splice($currentProviders.indexOf(e.detail.value))
-            : []
+        on:clear={() => {
+          $currentProviders = []
+          setViewportToDefault()
+          search()
         }}
-        value={$currentProviders.length ? $currentProviders : null}
         items={data.providers[0].providers.map(v => v.provider_name)}
-        isMulti={true}
+        value={$currentProviders}
+        multiple={true}
         placeholder="Select providers..."
       />
     </div>
-  </div>
+  </SvelteSelectCSS>
 </div>
 <MediaSearch
   {meilisearch}

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -127,6 +127,18 @@
   resolved "https://registry.yarnpkg.com/@esbuild/win32-x64/-/win32-x64-0.17.19.tgz#8cfaf2ff603e9aabb910e9c0558c26cf32744061"
   integrity sha512-lAhycmKnVOuRYNtRtatQR1LPQf2oYCkRGkSFnseDAKPl8lu5SOsK/e1sXe5a0Pc5kHIHe6P2I/ilntNv2xf3cA==
 
+"@floating-ui/core@^1.1.0", "@floating-ui/core@^1.3.1":
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/@floating-ui/core/-/core-1.3.1.tgz#4d795b649cc3b1cbb760d191c80dcb4353c9a366"
+  integrity sha512-Bu+AMaXNjrpjh41znzHqaz3r2Nr8hHuHZT6V2LBKMhyMl0FgKA62PNYbqnfgmzOhoWZj70Zecisbo4H1rotP5g==
+
+"@floating-ui/dom@^1.1.0", "@floating-ui/dom@^1.2.1":
+  version "1.4.3"
+  resolved "https://registry.yarnpkg.com/@floating-ui/dom/-/dom-1.4.3.tgz#0854a3297ea03894932381f3ea1403fab3a6e602"
+  integrity sha512-nB/68NyaQlcdY22L+Fgd1HERQ7UGv7XFN+tPxwrEfQL4nKtAP/jIZnZtpUlXbtV+VEGHh6W/63Gy2C5biWI3sA==
+  dependencies:
+    "@floating-ui/core" "^1.3.1"
+
 "@jridgewell/gen-mapping@^0.3.2":
   version "0.3.3"
   resolved "https://registry.yarnpkg.com/@jridgewell/gen-mapping/-/gen-mapping-0.3.3.tgz#7e02e6eb5df901aaedb08514203b096614024098"
@@ -1606,6 +1618,14 @@ svelte-check@^3.3.2:
     svelte-preprocess "^5.0.3"
     typescript "^5.0.3"
 
+svelte-floating-ui@1.2.8:
+  version "1.2.8"
+  resolved "https://registry.yarnpkg.com/svelte-floating-ui/-/svelte-floating-ui-1.2.8.tgz#1817473a1a26c17de6019da4603111b48ef8e7e8"
+  integrity sha512-8Ifi5CD2Ui7FX7NjJRmutFtXjrB8T/FMNoS2H8P81t5LHK4I9G4NIs007rLWG/nRl7y+zJUXa3tWuTjYXw/O5A==
+  dependencies:
+    "@floating-ui/core" "^1.1.0"
+    "@floating-ui/dom" "^1.1.0"
+
 svelte-hmr@^0.15.1:
   version "0.15.1"
   resolved "https://registry.yarnpkg.com/svelte-hmr/-/svelte-hmr-0.15.1.tgz#d11d878a0bbb12ec1cba030f580cd2049f4ec86b"
@@ -1632,9 +1652,13 @@ svelte-preprocess@^5.0.3:
     sorcery "^0.11.0"
     strip-indent "^3.0.0"
 
-"svelte-select@https://github.com/AndreasPB/svelte-select":
-  version "4.4.7"
-  resolved "https://github.com/AndreasPB/svelte-select#b0bb0b6a66fbe2866d218a58ea18bf5afb3ece78"
+svelte-select@^5.6.1:
+  version "5.6.1"
+  resolved "https://registry.yarnpkg.com/svelte-select/-/svelte-select-5.6.1.tgz#2626748c92ff3983c75f273d87afba59ffef3b29"
+  integrity sha512-Powj91VAWyaNMSSOQ0E29UMTw/ExWsHEsA83H7yQgfji2S2DhG6Rs5qZHslZ+ihbCPxXel5uEzwLsSqDABkQDw==
+  dependencies:
+    "@floating-ui/dom" "^1.2.1"
+    svelte-floating-ui "1.2.8"
 
 svelte@^3.59.1:
   version "3.59.1"


### PR DESCRIPTION
# Description

Adds search bar in navbar, when not on the index page, if screen size is above `1100px`.

Also updates our `svelte-select` version to the current one instead of our own forked version that is 2 majors behind. Furthermore also adds a component to add our `css` properties to the `svelte-select`.

Fixes #

#557 