### PR TITLE
keep index state

### DIFF
--- a/frontend/src/lib/components/media_search.svelte
+++ b/frontend/src/lib/components/media_search.svelte
@@ -24,8 +24,7 @@
 
 {#if meilisearch && meilisearch.hits.length}
   <div
-    class="grid grid-cols-2 2xl:grid-cols-7 xl:grid-cols-6 lg:grid-cols-5
-                    md:grid-cols-4 sm:grid-cols-3 gap-2 pt-2 pb-4"
+    class="grid grid-cols-2 gap-2 pt-2 pb-4 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 xl:grid-cols-6 2xl:grid-cols-7"
   >
     {#each meilisearch.hits as media, mediaIndex}
       <MediaCard {providerAmounts} {mediaIndex} {media} />
@@ -34,7 +33,7 @@
   {#if meilisearch.hits.length === meilisearch.limit}
     <InfiniteLoading on:infinite={loadMoreData} />
   {:else}
-    <p class="text-center italic">Showing {meilisearch.hits.length} results</p>
+    <p class="italic text-center">Showing {meilisearch.hits.length} results</p>
   {/if}
 {:else if meilisearch && meilisearch.hits.length === 0}
   <NoResults {currentProviders} {currentGenres} {input} />

--- a/frontend/src/routes/+page.svelte
+++ b/frontend/src/routes/+page.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import type { Snapshot } from "./$types"
   import { calculateAmountOfShownItems, hitProviderAmounts } from "$lib/utils"
   import { PYTHON_API } from "$lib/variables.js"
   import Select from "svelte-select"
@@ -29,6 +30,20 @@
   let viewPortWidth: number
   let currentMediaAmount: number
   let mediaStartAmount: number
+
+  let scrollAmount = 0
+
+  export const snapshot: Snapshot = {
+    capture() {
+      return { scrollY: window.scrollY }
+    },
+    restore({ scrollY, currentMediaAmount }) {
+      mediaStartAmount = currentMediaAmount
+      scrollAmount = scrollY
+      console.log(meilisearch)
+      console.log(scrollAmount)
+    },
+  }
 
   const setViewportToDefault = () => {
     viewPortWidth = window.visualViewport.width
@@ -149,14 +164,14 @@
 
 <Head title="streamchaser" />
 
-<div class="bg-neutral shadow-md card pb-2 pt-6 px-2 sm:px-6">
+<div class="px-2 pt-6 pb-2 shadow-md sm:px-6 bg-neutral card">
   <div class="flex justify-between">
     <!-- svelte-ignore a11y-autofocus -->
     <input
       id="input-field"
       type="text"
       placeholder="Search in {$currentCountry}"
-      class="input input-bordered input-primary grow min-w-0 hover:border-primary-focus"
+      class="min-w-0 input input-bordered input-primary grow hover:border-primary-focus"
       bind:value={input}
       on:input={search}
       autofocus={viewPortWidth > 640}
@@ -164,7 +179,7 @@
     <Filters {search} />
   </div>
   <div
-    class="sm:grid sm:grid-cols-2 sm:gap-2 mt-2 mb-3"
+    class="mt-2 mb-3 sm:grid sm:grid-cols-2 sm:gap-2"
     style="
              --borderRadius: var(--rounded-btn, .5rem);
              --background: hsl(var(--b1));


### PR DESCRIPTION
# Description

Please include a summary of the change and which issue is fixed.

This fixes the state of the index page when you navigate away from it. So when you get back, you can scroll from where you left off, instead of getting back to the top of the page.

Fixes #556 
