### PR TITLE
feat: stop processing media with no poster paths

### DIFF
--- a/internal/routes.go
+++ b/internal/routes.go
@@ -98,7 +98,7 @@ func processMedia(c *gin.Context) {
 			failedMedia++
 			continue
 		}
-		if movie.Popularity > 1 {
+		if movie.Popularity > 1 && movie.PosterPath != "" {
 			medias = append(medias, *movie.toMedia())
 		}
 	}
@@ -108,7 +108,7 @@ func processMedia(c *gin.Context) {
 			failedMedia++
 			continue
 		}
-		if tv.Popularity > 1 {
+		if tv.Popularity > 1 && tv.PosterPath != "" {
 			medias = append(medias, *tv.toMedia())
 		}
 	}
@@ -119,7 +119,7 @@ func processMedia(c *gin.Context) {
 			continue
 		}
 		// HACK: We let less people through since there's so many and we are getting throttled
-		if person.Popularity > 3 {
+		if person.Popularity > 3 && person.ProfilePath != "" {
 			medias = append(medias, *person.toMedia())
 		}
 	}


### PR DESCRIPTION
# Description

This stops us from processing media ane person with no images. They are usually unwanted or unknown and just adds a ton of media for us to index further down the line.
